### PR TITLE
SDK-748: Ensure pem file is permanent

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -69,7 +69,7 @@ $ docker-compose build --no-cache
 
 Install Drupal and enable Yoti module
 
-```
+```shell
 $ ./install-drupal.sh
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -65,24 +65,27 @@ Rebuild the images if you have modified any Docker file:
 $ docker-compose build --no-cache
 ```
 
+#### Quick Installation (Drush)
+
+Install Drupal and enable Yoti module
+
+```
+$ ./install-drupal.sh
+```
+
+Visit <https://localhost:8004> and follow the [module setup process](#module-setup)
+
+#### Manual Installation
+
 Build the containers:
 
 ```shell
 $ docker-compose up -d
 ```
 
-After the command has finished running, go to [https://localhost:8004](https://localhost:8004) and follow the instructions.
+After the command has finished running, go to <https://localhost:8004> and follow the instructions.
 
-### Database Configuration
-
-When prompted, enter the following database details:
-
-* Name `drupal`
-* Username `drupal`
-* Password `drupal`
-* Host `drupal-8-db`
-
-The Yoti module will be installed alongside Drupal. Activate it and follow our [module setup process](#module-setup).
+Enable the Yoti module and follow our [module setup process](#module-setup).
 
 ### Removing the Docker containers
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,16 @@ services:
       context: ./docker/
       args:
         BRANCH: "8.x-1.x"
+    depends_on:
+      - drupal-8-db
     ports:
-     - "8004:443"
+      - "8004:443"
+    environment:
+      MYSQL_HOSTNAME: drupal-8-db
+      MYSQL_DATABASE: drupal
+      MYSQL_PORT: 3306
+      MYSQL_USER: drupal
+      MYSQL_PASSWORD: drupal
     volumes:
       - /var/www/html/modules
       - /var/www/html/profiles

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,4 +74,9 @@ RUN git clone -b ${BRANCH} https://github.com/getyoti/yoti-drupal.git --single-b
         && unzip ${PLUGIN_PACKAGE_NAME} \
         && rm -f ${PLUGIN_PACKAGE_NAME}
 
+RUN mkdir /var/www/private \
+	&& chown www-data /var/www/private \
+	&& chmod 755 /var/www/private \
+	&& echo '$settings["file_private_path"] = "/var/www/private";' >> ${DIRPATH}/sites/default/default.settings.php;
+
 EXPOSE 443

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,9 +74,29 @@ RUN git clone -b ${BRANCH} https://github.com/getyoti/yoti-drupal.git --single-b
         && unzip ${PLUGIN_PACKAGE_NAME} \
         && rm -f ${PLUGIN_PACKAGE_NAME}
 
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install- dir=/usr/local/bin --filename=composer \
+    && mv composer /usr/local/bin
+
+# Install Drush
+RUN curl -L -o drush.phar https://github.com/drush-ops/drush-launcher/releases/download/0.4.2/drush.phar \
+    && chmod +x drush.phar \
+    && mv drush.phar /usr/local/bin/drush \
+    && composer require drush/drush:^9.0
+
+# Install MySQL Client
+RUN apt-get install -y mysql-client
+
+# Create writable public files directory
+RUN mkdir sites/default/files \
+    && chown www-data:www-data sites/default/files
+
+# Create private file directory
 RUN mkdir /var/www/private \
-	&& chown www-data /var/www/private \
-	&& chmod 755 /var/www/private \
-	&& echo '$settings["file_private_path"] = "/var/www/private";' >> ${DIRPATH}/sites/default/default.settings.php;
+    && chown www-data:www-data /var/www/private
+
+# Copy local Drupal settings
+COPY settings.php ${DIRPATH}/sites/default/settings.php
+RUN chown www-data:www-data sites/default/settings.php
 
 EXPOSE 443

--- a/docker/settings.php
+++ b/docker/settings.php
@@ -11,5 +11,5 @@ $databases['default']['default'] = [
   'username' => getenv('MYSQL_USER'),
 ];
 
-// Use environment variable for private file path
+// Configure private file path
 $settings['file_private_path'] = '/var/www/private';

--- a/docker/settings.php
+++ b/docker/settings.php
@@ -1,0 +1,15 @@
+<?php
+// Use environment variables for database
+$databases['default']['default'] = [
+  'database' => getenv('MYSQL_DATABASE'),
+  'driver' => 'mysql',
+  'host' => getenv('MYSQL_HOSTNAME'),
+  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+  'password' => getenv('MYSQL_PASSWORD'),
+  'port' => getenv('MYSQL_PORT'),
+  'prefix' => '',
+  'username' => getenv('MYSQL_USER'),
+];
+
+// Use environment variable for private file path
+$settings['file_private_path'] = '/var/www/private';

--- a/install-drupal.sh
+++ b/install-drupal.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+docker-compose up -d
+
+# Wait for services to be ready
+sleep 10
+
+# Install Drupal
+docker-compose exec drupal-8 drush site:install -y
+
+# Enable Yoti module
+docker-compose exec drupal-8 drush en yoti -y

--- a/yoti/src/Form/YotiSettingsForm.php
+++ b/yoti/src/Form/YotiSettingsForm.php
@@ -158,8 +158,8 @@ class YotiSettingsForm extends ConfigFormBase {
     $pemFile = $config->get('yoti_pem');
     $file = (NULL !== $pemFile[0]) ? File::load($pemFile[0]) : NULL;
     // Change status to permanent.
-    if ($file && is_object(gettype($file))) {
-      $file->status = FILE_STATUS_PERMANENT;
+    if ($file && is_object($file)) {
+      $file->setPermanent();
       // Save.
       $file->save();
       $user = User::load(Drupal::currentUser()->id());

--- a/yoti/src/YotiHelper.php
+++ b/yoti/src/YotiHelper.php
@@ -630,8 +630,7 @@ class YotiHelper {
 
     $pem = $settings->get('yoti_pem');
     $name = $contents = NULL;
-    if ($pem) {
-      $file = File::load($pem[0]);
+    if (isset($pem[0]) && ($file = File::load($pem[0]))) {
       $name = $file->getFileUri();
       $contents = file_get_contents(\Drupal::service('file_system')->realpath($name));
     }


### PR DESCRIPTION
- Removed `gettype()` as this returns a string
- Using [File::setPermanent()](https://api.drupal.org/api/drupal/core%21modules%21file%21src%21Entity%21File.php/function/File%3A%3AsetPermanent/8.2.x)
- Checking file was loaded before using it in `yoti/src/YotiHelper.php`
- Updated `docker/Dockerfile`
  - Sets up a private directory so that module can be enabled
  - Enabling `drush`
  - Providing `settings.php` for easier installation
- Introduced `install-drupal.sh` to install Drupal and enable Yoti module

>Set `BRANCH: "SDK-748"` in `docker-compose.yml` to install this branch