### PR TITLE
SDK-790: Cache invalidation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -107,6 +107,14 @@ $ ./install-drupal.sh drupal-8-dev
 
 To use Xdebug in an IDE, map the `/var/www/html/modules/yoti` volume to the module directory on the host machine.
 
+### Running Tests
+
+To check coding standards and run unit tests:
+
+```shell
+$ ./run-tests.sh
+```
+
 ### Removing the Docker containers
 
 Run the following commands to remove docker containers:

--- a/docker/app.dev.dockerfile
+++ b/docker/app.dev.dockerfile
@@ -3,6 +3,7 @@ FROM docker_drupal-8-base:latest
 # Install and configure xdebug.
 RUN yes | pecl install xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.extension.ini
+COPY ./docker/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 
 # Install PHP_CodeSniffer
 RUN composer require dealerdirect/phpcodesniffer-composer-installer
@@ -10,5 +11,3 @@ RUN composer require dealerdirect/phpcodesniffer-composer-installer
 # Upgrade and configure PHPUnit
 COPY ./docker/phpunit.xml .
 RUN composer run-script drupal-phpunit-upgrade
-
-COPY ./docker/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini

--- a/docker/app.dev.dockerfile
+++ b/docker/app.dev.dockerfile
@@ -4,4 +4,11 @@ FROM docker_drupal-8-base:latest
 RUN yes | pecl install xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.extension.ini
 
+# Install PHP_CodeSniffer
+RUN composer require dealerdirect/phpcodesniffer-composer-installer
+
+# Upgrade and configure PHPUnit
+COPY ./docker/phpunit.xml .
+RUN composer run-script drupal-phpunit-upgrade
+
 COPY ./docker/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini

--- a/docker/phpunit.xml
+++ b/docker/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="core/tests/bootstrap.php"
+         verbose="true"
+        >
+    <testsuites>
+        <testsuite name="Yoti tests">
+            <directory>./modules/yoti</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/docker/run-tests.sh
+++ b/docker/run-tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+docker-compose up -d drupal-8-dev
+
+# Coding Standards
+docker-compose exec drupal-8-dev ./vendor/bin/phpcs --standard=Drupal --ignore=*/var/www/html/modules/yoti/sdk* ./modules/yoti
+
+# Run Unit Tests
+docker-compose exec drupal-8-dev ./vendor/bin/phpunit

--- a/yoti/js/browser-loader.js
+++ b/yoti/js/browser-loader.js
@@ -3,7 +3,7 @@
     var script = document.createElement('script');
     script.type='text/javascript';
     script.async='async';
-    script.src='https://sdk.yoti.com/clients/browser.2.1.0.js';
+    script.src='https://sdk.yoti.com/clients/browser.2.2.0.js';
 
     // Initialise button once browser JS is loaded.
     script.addEventListener('load', function() {

--- a/yoti/js/browser-loader.js
+++ b/yoti/js/browser-loader.js
@@ -1,0 +1,19 @@
+(function(){
+    // Create browser script tag.
+    var script = document.createElement('script');
+    script.type='text/javascript';
+    script.async='async';
+    script.src='https://sdk.yoti.com/clients/browser.2.1.0.js';
+
+    // Initialise button once browser JS is loaded.
+    script.addEventListener('load', function() {
+        // Collect inline _ybg config.
+        var config = window._ybg_config || {};
+        for (i in config) {
+            _ybg.config[i] = config[i];
+        }
+        _ybg.init();
+    });
+
+    document.head.appendChild(script);
+})();

--- a/yoti/src/Controller/YotiStartController.php
+++ b/yoti/src/Controller/YotiStartController.php
@@ -8,6 +8,7 @@ use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\yoti\YotiHelper;
 use Drupal\yoti\Models\YotiUserModel;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Drupal\Core\Cache\Cache;
 
 require_once __DIR__ . '/../../sdk/boot.php';
 
@@ -32,9 +33,6 @@ class YotiStartController extends ControllerBase {
       return new TrustedRedirectResponse($helper::getLoginUrl());
     }
 
-    $this->cache('dynamic_page_cache')->deleteAll();
-    $this->cache('render')->deleteAll();
-
     $result = $helper->link();
     if (!$result) {
       $failedURL = YotiHelper::getPathFullUrl($config['yoti_fail_url']);
@@ -54,9 +52,6 @@ class YotiStartController extends ControllerBase {
   public function unlink() {
     /** @var \Drupal\yoti\YotiHelper $helper */
     $helper = Drupal::service('yoti.helper');
-
-    $this->cache('dynamic_page_cache')->deleteAll();
-    $this->cache('render')->deleteAll();
 
     $helper->unlink();
     return $this->redirect('user.login');

--- a/yoti/src/Controller/YotiStartController.php
+++ b/yoti/src/Controller/YotiStartController.php
@@ -8,7 +8,6 @@ use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\yoti\YotiHelper;
 use Drupal\yoti\Models\YotiUserModel;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Drupal\Core\Cache\Cache;
 
 require_once __DIR__ . '/../../sdk/boot.php';
 

--- a/yoti/src/Plugin/Block/YotiBlock.php
+++ b/yoti/src/Plugin/Block/YotiBlock.php
@@ -40,57 +40,37 @@ class YotiBlock extends BlockBase {
       return [];
     }
 
-    $script = [];
-
     // If connect url starts with 'https://staging' then we are in staging mode.
-    $isStaging = strpos(YotiClient::CONNECT_BASE_URL, 'https://staging') === 0;
-    if ($isStaging) {
+    $qr_url = NULL;
+    $service_url = NULL;
+    $is_staging = strpos(YotiClient::CONNECT_BASE_URL, 'https://staging') === 0;
+    if ($is_staging) {
       // Base url for connect.
-      $baseUrl = preg_replace('/^(.+)\/connect$/', '$1', YotiClient::CONNECT_BASE_URL);
-
-      $script[] = 'var _ybg_config = {};';
-      $script[] = sprintf('_ybg_config.qr = "%s/qr/";', $baseUrl);
-      $script[] = sprintf('_ybg_config.service = "%s/connect/";', $baseUrl);
+      $base_url = preg_replace('/^(.+)\/connect$/', '$1', YotiClient::CONNECT_BASE_URL);
+      $qr_url = sprintf('%s/qr/', $base_url);
+      $service_url = sprintf('%s/connect/', $base_url);
     }
 
-    $script = implode("\r\n", $script);
-
-    // Prep button.
-    $linkButton = '<span
-            data-yoti-application-id="' . $config['yoti_app_id'] . '"
-            data-yoti-type="inline"
-            data-yoti-scenario-id="' . $config['yoti_scenario_id'] . '"
-            data-size="small">
-            %s
-        </span>';
-
+    // Set button text based on current user.
     $userId = $user->id();
     if (!$userId) {
-      $button = sprintf($linkButton, YotiHelper::YOTI_LINK_BUTTON_DEFAULT_TEXT);
+      $button_text = YotiHelper::YOTI_LINK_BUTTON_DEFAULT_TEXT;
+      $is_linked = FALSE;
     }
     else {
-      $dbProfile = YotiUserModel::getYotiUserById($userId);
-      if ($dbProfile) {
-        $button = '<strong>Yoti</strong> Linked';
-      }
-      else {
-        $button = sprintf($linkButton, 'Link to Yoti');
-      }
+      $button_text = 'Link to Yoti';
+      $is_linked = YotiUserModel::getYotiUserById($userId) ? TRUE : FALSE;
     }
 
-    $html = '<div class="yoti-connect">' . $button . '</div>';
-
     return [
-      'inside' => [
-        '#type' => 'html_tag',
-        '#tag' => 'div',
-        '#value' => $html,
-        'inside' => [
-          '#type' => 'html_tag',
-          '#tag' => 'script',
-          '#value' => '<script>' . $script . '</script>',
-        ],
-      ],
+      '#theme' => 'yoti_button',
+      '#app_id' => $config['yoti_app_id'],
+      '#scenario_id' => $config['yoti_scenario_id'],
+      '#button_text' => $button_text,
+      '#is_linked' => $is_linked,
+      '#is_staging' => $is_staging,
+      '#qr_url' => $qr_url,
+      '#service_url' => $service_url,
       '#attached' => [
         'library' => [
           'yoti/yoti',

--- a/yoti/src/Plugin/Block/YotiBlock.php
+++ b/yoti/src/Plugin/Block/YotiBlock.php
@@ -6,6 +6,7 @@ use Yoti\YotiClient;
 use Drupal\Core\Block\BlockBase;
 use Drupal\yoti\YotiHelper;
 use Drupal\yoti\Models\YotiUserModel;
+use Drupal\Core\Cache\Cache;
 
 /**
  * Provides a 'Yoti' Block.
@@ -47,12 +48,11 @@ class YotiBlock extends BlockBase {
       // Base url for connect.
       $baseUrl = preg_replace('/^(.+)\/connect$/', '$1', YotiClient::CONNECT_BASE_URL);
 
-      $script[] = sprintf('_ybg.config.qr = "%s/qr/";', $baseUrl);
-      $script[] = sprintf('_ybg.config.service = "%s/connect/";', $baseUrl);
+      $script[] = 'var _ybg_config = {};';
+      $script[] = sprintf('_ybg_config.qr = "%s/qr/";', $baseUrl);
+      $script[] = sprintf('_ybg_config.service = "%s/connect/";', $baseUrl);
     }
 
-    // Add init()
-    $script[] = '_ybg.init();';
     $script = implode("\r\n", $script);
 
     // Prep button.
@@ -99,4 +99,10 @@ class YotiBlock extends BlockBase {
     ];
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    return Cache::mergeContexts(parent::getCacheContexts(), ['user']);
+  }
 }

--- a/yoti/src/Plugin/Block/YotiBlock.php
+++ b/yoti/src/Plugin/Block/YotiBlock.php
@@ -105,4 +105,5 @@ class YotiBlock extends BlockBase {
   public function getCacheContexts() {
     return Cache::mergeContexts(parent::getCacheContexts(), ['user']);
   }
+
 }

--- a/yoti/src/YotiHelper.php
+++ b/yoti/src/YotiHelper.php
@@ -118,9 +118,6 @@ class YotiHelper {
       $currentUser = Drupal::currentUser();
     }
 
-    // Invalidate cache for current user.
-    $this->invalidateUserCache($currentUser->id());
-
     $token = (!empty($_GET['token'])) ? $_GET['token'] : NULL;
 
     // If no token then ignore.
@@ -151,6 +148,9 @@ class YotiHelper {
       self::setFlash("Could not log you in as you haven't passed the age verification", 'error');
       return FALSE;
     }
+
+    // Invalidate cache for current user.
+    $this->invalidateUserCache($currentUser->id());
 
     // Check if Yoti user exists.
     $drupalUid = $this->getDrupalUid($activityDetails->getRememberMeId());
@@ -289,7 +289,7 @@ class YotiHelper {
    *   The Drupal user ID.
    */
   private function invalidateUserCache($userId) {
-    if ($user = User::load($userId)) {
+    if ($user = $this->userStorage->load($userId)) {
       $this->cacheTagsInvalidator->invalidateTags($user->getCacheTagsToInvalidate());
     }
   }
@@ -342,7 +342,7 @@ class YotiHelper {
    *   Notification status.
    */
   public static function setFlash($message, $type = 'status') {
-    drupal_set_message($message, $type);
+    \Drupal::messenger()->addMessage($message, $type);
   }
 
   /**

--- a/yoti/src/YotiHelper.php
+++ b/yoti/src/YotiHelper.php
@@ -14,7 +14,7 @@ use Yoti\ActivityDetails;
 use Yoti\YotiClient;
 use Yoti\Entity\Profile;
 use Yoti\Entity\AgeVerification;
-use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 
 require_once __DIR__ . '/../sdk/boot.php';
 
@@ -76,12 +76,22 @@ class YotiHelper {
   private $config;
 
   /**
+   * Cache tag invalidator.
+   *
+   * @var CacheTagsInvalidatorInterface
+   */
+  private $cacheTagsInvalidator;
+
+  /**
    * YotiHelper constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityManager
    *   Entity Type Manager.
    */
-  public function __construct(EntityTypeManagerInterface $entityManager) {
+  public function __construct(
+    EntityTypeManagerInterface $entityManager,
+    CacheTagsInvalidatorInterface $cacheTagsInvalidator
+  ) {
     try {
       $this->userStorage = $entityManager->getStorage('user');
     }
@@ -90,6 +100,7 @@ class YotiHelper {
     }
 
     $this->config = self::getConfig();
+    $this->cacheTagsInvalidator = $cacheTagsInvalidator;
   }
 
   /**
@@ -269,7 +280,7 @@ class YotiHelper {
    */
   private function invalidateUserCache($userId) {
     if ($user = User::load($userId)) {
-      Cache::invalidateTags($user->getCacheTagsToInvalidate());
+      $this->cacheTagsInvalidator->invalidateTags($user->getCacheTagsToInvalidate());
     }
   }
 

--- a/yoti/templates/yoti-button.html.twig
+++ b/yoti/templates/yoti-button.html.twig
@@ -1,0 +1,39 @@
+{#
+/**
+ * @file
+ * Yoti Button.
+ *
+ * Available variables:
+ * - app_id: Yoti App ID
+ * - scenario_id: Yoti Scenario ID
+ * - button_text: Button Text
+ * - is_linked: Flag for linked accounts
+ * - is_staging: Flag for staging
+ * - qr_url: QR URL
+ * - service_url: Service URL
+ */
+#}
+<div class="yoti-connect">
+{% if is_linked %}
+    <strong>Yoti</strong> Linked
+{% else %}
+    <span
+        data-yoti-application-id="{{app_id}}"
+        data-yoti-type="inline"
+        data-yoti-scenario-id="{{scenario_id}}"
+        data-size="small">
+        {{button_text}}
+    </span>
+    {% if is_staging %}
+    <script>
+        var _ybg_config = {};
+        {% if qr_url %}
+        _ybg_config.qr = "{{qr_url}}";
+        {% endif %}
+        {% if service_url %}
+        _ybg_config.service = "{{service_url}}";
+        {% endif %}
+    </script>
+    {% endif %}
+{% endif %}
+</div>

--- a/yoti/tests/src/Unit/YotiHelperTest.php
+++ b/yoti/tests/src/Unit/YotiHelperTest.php
@@ -28,10 +28,10 @@ class YotiHelperTest extends UnitTestCase {
     // Setup container to handle situations where dependencies
     // haven't been injected.
     $container = new ContainerBuilder();
-    $container->set('config.factory', $this->getMockConfigFactory());
+    $container->set('config.factory', $this->createMockConfigFactory());
     $container->set('current_user', $this->getMock(AccountProxyInterface::class));
     $container->set('messenger', $this->getMock(MessengerInterface::class));
-    $container->set('database', $this->getMockDatabase());
+    $container->set('database', $this->createMockDatabase());
     \Drupal::setContainer($container);
   }
 
@@ -46,7 +46,7 @@ class YotiHelperTest extends UnitTestCase {
       ->expects($this->exactly(0))
       ->method('invalidateTags');
 
-    $helper = new YotiHelper($this->getEntityTypeManager(), $cacheTagsInvalidator);
+    $helper = new YotiHelper($this->createMockEntityTypeManager(), $cacheTagsInvalidator);
 
     // Attempt link with no token.
     $result = $helper->link();
@@ -69,17 +69,17 @@ class YotiHelperTest extends UnitTestCase {
       ->method('invalidateTags')
       ->with($this->equalTo(['tag:1', 'tag:2']));
 
-    $helper = new YotiHelper($this->getEntityTypeManager(), $cacheTagsInvalidator);
+    $helper = new YotiHelper($this->createMockEntityTypeManager(), $cacheTagsInvalidator);
     $helper->unlink();
   }
 
   /**
-   * Get mock for entity type manager.
+   * Creates mock entity type manager.
    *
    * @return \Drupal\Core\Entity\EntityTypeManagerInterface
    *   Mocked entity type manager
    */
-  private function getEntityTypeManager() {
+  private function createMockEntityTypeManager() {
     // Mock user storage.
     $user = $this->getMock(EntityInterface::class);
     $user
@@ -106,12 +106,12 @@ class YotiHelperTest extends UnitTestCase {
   }
 
   /**
-   * Get mocked database connection.
+   * Creates mock database connection.
    *
    * @return \Drupal\Core\Database\Connection
    *   Mocked database connection.
    */
-  private function getMockDatabase() {
+  private function createMockDatabase() {
     // Mock database connextion.
     $database = $this->getMockBuilder(Connection::class)
       ->disableOriginalConstructor()
@@ -135,12 +135,12 @@ class YotiHelperTest extends UnitTestCase {
   }
 
   /**
-   * Get mock config factory.
+   * Creates mock config factory.
    *
    * @return \Drupal\Core\Config\ConfigFactoryInterface
    *   Mocked config factory.
    */
-  private function getMockConfigFactory() {
+  private function createMockConfigFactory() {
     return $this->getConfigFactoryStub([
       'yoti.settings' => [
         'yoti_app_id' => 'app_id',

--- a/yoti/tests/src/Unit/YotiHelperTest.php
+++ b/yoti/tests/src/Unit/YotiHelperTest.php
@@ -50,11 +50,11 @@ class YotiHelperTest extends UnitTestCase {
 
     // Attempt link with no token.
     $result = $helper->link();
+    $this->assertFalse($result);
 
     // Attempt link with an invalid token.
     $_GET['token'] = 'test_token';
     $result = $helper->link();
-
     $this->assertFalse($result);
   }
 

--- a/yoti/tests/src/Unit/YotiHelperTest.php
+++ b/yoti/tests/src/Unit/YotiHelperTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Drupal\Tests\yoti\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\yoti\YotiHelper;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Database\Query\Delete;
+
+/**
+ * @coversDefaultClass \Drupal\yoti\YotiHelper
+ *
+ * @group yoti
+ */
+class YotiHelperTest extends UnitTestCase {
+
+  /**
+   * Setup for YotiHelper tests.
+   */
+  public function setUp() {
+    // Setup container to handle situations where dependencies
+    // haven't been injected.
+    $container = new ContainerBuilder();
+    $container->set('config.factory', $this->getMockConfigFactory());
+    $container->set('current_user', $this->getMock(AccountProxyInterface::class));
+    $container->set('messenger', $this->getMock(MessengerInterface::class));
+    $container->set('database', $this->getMockDatabase());
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * @covers ::link
+   * @backupGlobals enabled
+   */
+  public function testLinkInvalidToken() {
+    // Cache should not be invalidated if invalid token is provided.
+    $cacheTagsInvalidator = $this->getMock(CacheTagsInvalidatorInterface::class);
+    $cacheTagsInvalidator
+      ->expects($this->exactly(0))
+      ->method('invalidateTags');
+
+    $helper = new YotiHelper($this->getEntityTypeManager(), $cacheTagsInvalidator);
+
+    // Attempt link with no token.
+    $result = $helper->link();
+
+    // Attempt link with an invalid token.
+    $_GET['token'] = 'test_token';
+    $result = $helper->link();
+
+    $this->assertFalse($result);
+  }
+
+  /**
+   * @covers ::unlink
+   */
+  public function testUnlinkCacheInvalidation() {
+    // Cache should be invalidated when user is unlinked.
+    $cacheTagsInvalidator = $this->getMock(CacheTagsInvalidatorInterface::class);
+    $cacheTagsInvalidator
+      ->expects($this->once())
+      ->method('invalidateTags')
+      ->with($this->equalTo(['tag:1', 'tag:2']));
+
+    $helper = new YotiHelper($this->getEntityTypeManager(), $cacheTagsInvalidator);
+    $helper->unlink();
+  }
+
+  /**
+   * Get mock for entity type manager.
+   *
+   * @return \Drupal\Core\Entity\EntityTypeManagerInterface
+   *   Mocked entity type manager
+   */
+  private function getEntityTypeManager() {
+    // Mock user storage.
+    $user = $this->getMock(EntityInterface::class);
+    $user
+      ->method('id')
+      ->willReturn('2');
+    $user
+      ->method('getCacheTagsToInvalidate')
+      ->willReturn(['tag:1', 'tag:2']);
+
+    $userStorage = $this->getMock(EntityStorageInterface::class);
+    $userStorage
+      ->method('load')
+      ->willReturn($user);
+
+    // Mock entity type manager.
+    $entityManager = $this->getMock(EntityTypeManagerInterface::class);
+    $entityManager
+      ->method('getStorage')
+      ->will($this->returnValueMap([
+        ['user', $userStorage],
+      ]));
+
+    return $entityManager;
+  }
+
+  /**
+   * Get mocked database connection.
+   *
+   * @return \Drupal\Core\Database\Connection
+   *   Mocked database connection.
+   */
+  private function getMockDatabase() {
+    // Mock database connextion.
+    $database = $this->getMockBuilder(Connection::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['delete'])
+      ->getMockForAbstractClass();
+
+    // Mock delete query.
+    $deleteQuery = $this->getMockBuilder(Delete::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['condition', 'execute'])
+      ->getMockForAbstractClass();
+    $deleteQuery->method('condition')
+      ->willReturn($deleteQuery);
+    $deleteQuery->method('execute')
+      ->willReturn([]);
+    $database
+      ->method('delete')
+      ->willReturn($deleteQuery);
+
+    return $database;
+  }
+
+  /**
+   * Get mock config factory.
+   *
+   * @return \Drupal\Core\Config\ConfigFactoryInterface
+   *   Mocked config factory.
+   */
+  private function getMockConfigFactory() {
+    return $this->getConfigFactoryStub([
+      'yoti.settings' => [
+        'yoti_app_id' => 'app_id',
+        'yoti_scenario_id' => 'scenario_id',
+        'yoti_sdk_id' => 'sdk_id',
+        'yoti_only_existing' => 1,
+        'yoti_success_url' => '/user',
+        'yoti_fail_url' => '/',
+        'yoti_user_email' => 'user@example.com',
+        'yoti_age_verification' => 0,
+        'yoti_company_name' => 'company_name',
+        'yoti_pem' => [
+          'name' => 'pem_name',
+          'contents' => 'pem_contents',
+        ],
+      ],
+    ]);
+  }
+
+}

--- a/yoti/yoti.libraries.yml
+++ b/yoti/yoti.libraries.yml
@@ -1,8 +1,9 @@
 yoti:
-  header: true
   version: 1.x
   js:
-    https://sdk.yoti.com/clients/browser.2.1.0.js: { type: external }
+    js/browser-loader.js:
+      attributes:
+        async: async
   css:
     theme:
       css/yoti.css: {}

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -115,7 +115,7 @@ function yoti_user_view(array &$build, UserInterface $account) {
 }
 
 /**
- * Implements hook_ENTITY_TYPE_insert().
+ * Implements hook_user_login().
  */
 function yoti_user_login($account) {
   $activityDetails = YotiHelper::getYotiUserFromStore();

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -21,6 +21,25 @@ function yoti_map_params() {
 }
 
 /**
+ * Implements hook_theme().
+ */
+function yoti_theme($existing, $type, $theme, $path) {
+  return [
+    'yoti_button' => [
+      'variables' => [
+        'app_id' => NULL,
+        'scenario_id' => NULL,
+        'button_text' => NULL,
+        'is_staging' => NULL,
+        'is_linked' => NULL,
+        'qr_url' => NULL,
+        'service_url' => NULL,
+      ],
+    ],
+  ];
+}
+
+/**
  * Implements hook_entity_extra_field_info().
  */
 function yoti_entity_extra_field_info() {

--- a/yoti/yoti.services.yml
+++ b/yoti/yoti.services.yml
@@ -1,5 +1,4 @@
 services:
   yoti.helper:
     class: Drupal\yoti\YotiHelper
-    arguments:
-      - '@entity_type.manager'
+    arguments: ['@entity_type.manager', '@cache_tags.invalidator']


### PR DESCRIPTION
- Invalidate cache tags for current user
- Wrapped loading of browser JS in `yoti/js/browser-loader.js` to allow for asynchronous loading (synchronous JS wasn't working when loaded by Drupal's Bigpipe)
- Setup coding standards checks and unit tests
- Added some test coverage for cache invalidation
- Created `yoti_button` theme, to move HTML away from PHP code
