### PR TITLE
SDK-924: Error messages

### DIFF
--- a/yoti/src/Controller/YotiStartController.php
+++ b/yoti/src/Controller/YotiStartController.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\yoti\Controller;
 
-use Drupal;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\yoti\YotiHelper;
@@ -24,7 +23,7 @@ class YotiStartController extends ControllerBase {
    */
   public function link() {
     /** @var \Drupal\yoti\YotiHelper $helper */
-    $helper = Drupal::service('yoti.helper');
+    $helper = \Drupal::service('yoti.helper');
     $config = YotiHelper::getConfig();
 
     // If no token is given check if we are in mock request mode.
@@ -50,7 +49,7 @@ class YotiStartController extends ControllerBase {
    */
   public function unlink() {
     /** @var \Drupal\yoti\YotiHelper $helper */
-    $helper = Drupal::service('yoti.helper');
+    $helper = \Drupal::service('yoti.helper');
 
     $helper->unlink();
     return $this->redirect('user.login');
@@ -60,7 +59,7 @@ class YotiStartController extends ControllerBase {
    * Send binary file from Yoti.
    */
   public function binFile($field) {
-    $current = Drupal::currentUser();
+    $current = \Drupal::currentUser();
     $isAdmin = in_array('administrator', $current->getRoles(), TRUE);
     $userId = (!empty($_GET['user_id']) && $isAdmin) ? (int) $_GET['user_id'] : $current->id();
     $dbProfile = YotiUserModel::getYotiUserById($userId);

--- a/yoti/src/Form/YotiSettingsForm.php
+++ b/yoti/src/Form/YotiSettingsForm.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\yoti\Form;
 
-use Drupal;
 use Drupal\user\Entity\User;
 use Drupal\file\Entity\File;
 use Drupal\Core\Url;
@@ -49,7 +48,7 @@ class YotiSettingsForm extends ConfigFormBase {
     // Make sure private path exists, if not, create it.
     $path = YotiHelper::uploadDir();
     if ($path && !is_dir($path)) {
-      Drupal::service('file_system')->mkdir($path, 0777);
+      \Drupal::service('file_system')->mkdir($path, 0777);
     }
 
     $config = $this->config('yoti.settings');
@@ -162,10 +161,10 @@ class YotiSettingsForm extends ConfigFormBase {
       $file->setPermanent();
       // Save.
       $file->save();
-      $user = User::load(Drupal::currentUser()->id());
+      $user = User::load(\Drupal::currentUser()->id());
       $file->setOwner($user);
       // Record the module (in this example, user module) is using the file.
-      Drupal::service('file.usage')->add($file, 'yoti', 'yoti', $file->id());
+      \Drupal::service('file.usage')->add($file, 'yoti', 'yoti', $file->id());
     }
 
     return parent::buildForm($form, $form_state);

--- a/yoti/src/Models/YotiUserModel.php
+++ b/yoti/src/Models/YotiUserModel.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\yoti\Models;
 
-use Drupal;
 use Drupal\yoti\YotiHelper;
 use Yoti\ActivityDetails;
 
@@ -26,7 +25,7 @@ class YotiUserModel {
   public static function getYotiUserById($userId) {
     $userProfile = NULL;
     if (!empty($userId)) {
-      $userProfile = Drupal::database()
+      $userProfile = \Drupal::database()
         ->select(YotiHelper::YOTI_USER_TABLE_NAME, 'u')
         ->fields('u')
         ->condition('uid', (int) $userId)
@@ -97,7 +96,7 @@ class YotiUserModel {
   public static function removeDuplicatedFieldsFromYotiUserTable() {
     $table_name = YotiHelper::YOTI_USER_TABLE_NAME;
     $ret = [];
-    $dbConn = Drupal::database();
+    $dbConn = \Drupal::database();
     $ret[] = $dbConn->schema()->dropField($table_name, 'selfie_filename');
     $ret[] = $dbConn->schema()->dropField($table_name, 'phone_number');
     $ret[] = $dbConn->schema()->dropField($table_name, 'date_of_birth');
@@ -134,7 +133,7 @@ class YotiUserModel {
 
     $col = NULL;
     if (!empty($yotiId) && !empty($field)) {
-      $col = Drupal::database()
+      $col = \Drupal::database()
         ->select(YotiHelper::YOTI_USER_TABLE_NAME, 'u')
         ->fields('u', ['uid'])
         ->condition($field, $yotiId)
@@ -158,7 +157,7 @@ class YotiUserModel {
    * @throws \Exception
    */
   public static function createYotiUser($userId, ActivityDetails $activityDetails, array $meta) {
-    Drupal::database()->insert(YotiHelper::YOTI_USER_TABLE_NAME)->fields([
+    \Drupal::database()->insert(YotiHelper::YOTI_USER_TABLE_NAME)->fields([
       'uid' => $userId,
       'identifier' => $activityDetails->getRememberMeId(),
       'data' => serialize($meta),
@@ -172,7 +171,7 @@ class YotiUserModel {
    *   User Id.
    */
   public static function deleteYotiUserById($userId) {
-    Drupal::database()->delete(YotiHelper::YOTI_USER_TABLE_NAME)->condition("uid", $userId)->execute();
+    \Drupal::database()->delete(YotiHelper::YOTI_USER_TABLE_NAME)->condition("uid", $userId)->execute();
   }
 
   /**
@@ -187,7 +186,7 @@ class YotiUserModel {
   public static function getUsernameCountByPrefix($prefix) {
     $usernameCount = 0;
     if (!empty($prefix)) {
-      $userQuery = Drupal::database()->select('users_field_data', 'uf');
+      $userQuery = \Drupal::database()->select('users_field_data', 'uf');
       $userQuery->fields('uf', ['name']);
       $userQuery->condition('name', $userQuery->escapeLike($prefix) . '%', 'LIKE');
       $results = $userQuery->execute()->fetchAll();
@@ -208,9 +207,9 @@ class YotiUserModel {
   public static function getUserEmailCountByPrefix($prefix) {
     $emailCount = 0;
     if (!empty($prefix)) {
-      $userQuery = Drupal::database()->select('users_field_data', 'uf');
+      $userQuery = \Drupal::database()->select('users_field_data', 'uf');
       $userQuery->fields('uf', ['mail']);
-      $userQuery->condition('mail', Drupal::database()->escapeLike($prefix) . '%', 'LIKE');
+      $userQuery->condition('mail', \Drupal::database()->escapeLike($prefix) . '%', 'LIKE');
       $results = $userQuery->execute()->fetchAll();
       $emailCount = count($results);
     }

--- a/yoti/src/YotiConfig.php
+++ b/yoti/src/YotiConfig.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Drupal\yoti;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+
+/**
+ * Class YotiConfig.
+ *
+ * @package Drupal\yoti
+ */
+class YotiConfig implements YotiConfigInterface {
+
+  /**
+   * Yoti plugin config data.
+   *
+   * @var Drupal\Core\Config\ConfigFactoryInterface
+   */
+  private $configFactory;
+
+  /**
+   * Yoti plugin config data.
+   *
+   * @var array
+   */
+  private $config;
+
+  /**
+   * YotiConfig constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   Yoti plugin config data.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+    $this->setConfig();
+  }
+
+  /**
+   * Set config array from config storage.
+   */
+  private function setConfig() {
+    $settings = $this->configFactory->get('yoti.settings');
+
+    $pem = $settings->get('yoti_pem');
+    $name = $contents = NULL;
+    if (isset($pem[0]) && ($file = File::load($pem[0]))) {
+      $name = $file->getFileUri();
+      $contents = file_get_contents(\Drupal::service('file_system')->realpath($name));
+    }
+    $this->config = [
+      'yoti_app_id' => $settings->get('yoti_app_id'),
+      'yoti_scenario_id' => $settings->get('yoti_scenario_id'),
+      'yoti_sdk_id' => $settings->get('yoti_sdk_id'),
+      'yoti_only_existing' => $settings->get('yoti_only_existing'),
+      'yoti_success_url' => $settings->get('yoti_success_url') ?: '/user',
+      'yoti_fail_url' => $settings->get('yoti_fail_url') ?: '/',
+      'yoti_user_email' => $settings->get('yoti_user_email'),
+      'yoti_age_verification' => $settings->get('yoti_age_verification'),
+      'yoti_company_name' => $settings->get('yoti_company_name'),
+      'yoti_pem' => compact('name', 'contents'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfig() {
+    return $this->config;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAppId() {
+    return $this->config['yoti_app_id'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getScenarioId() {
+    return $this->config['yoti_scenario_id'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSdkId() {
+    return $this->config['yoti_sdk_id'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOnlyExisting() {
+    return $this->config['yoti_only_existing'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSuccessUrl() {
+    return $this->config['yoti_success_url'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFailUrl() {
+    return $this->config['yoti_fail_url'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getUserEmail() {
+    return $this->config['yoti_user_email'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAgeVerification() {
+    return $this->config['yoti_age_verification'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCompanyName() {
+    return $this->config['yoti_company_name'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPemContents() {
+    return $this->config['yoti_pem']['contents'];
+  }
+
+}

--- a/yoti/src/YotiConfig.php
+++ b/yoti/src/YotiConfig.php
@@ -12,7 +12,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 class YotiConfig implements YotiConfigInterface {
 
   /**
-   * Yoti plugin config data.
+   * Config factory.
    *
    * @var Drupal\Core\Config\ConfigFactoryInterface
    */

--- a/yoti/src/YotiConfig.php
+++ b/yoti/src/YotiConfig.php
@@ -29,7 +29,7 @@ class YotiConfig implements YotiConfigInterface {
    * YotiConfig constructor.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   Yoti plugin config data.
+   *   Config factory.
    */
   public function __construct(ConfigFactoryInterface $config_factory) {
     $this->configFactory = $config_factory;

--- a/yoti/src/YotiConfig.php
+++ b/yoti/src/YotiConfig.php
@@ -3,6 +3,8 @@
 namespace Drupal\yoti;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 
 /**
  * Class YotiConfig.
@@ -19,20 +21,44 @@ class YotiConfig implements YotiConfigInterface {
   private $configFactory;
 
   /**
-   * Yoti plugin config data.
+   * File Storage.
+   *
+   * @var Drupal\Core\Entity\EntityStorageInterface
+   */
+  private $fileStorage;
+
+  /**
+   * File System.
+   *
+   * @var Drupal\Core\File\FileSystemInterface
+   */
+  private $fileSystem;
+
+  /**
+   * Yoti plugin settings.
    *
    * @var array
    */
-  private $config;
+  private $settings;
 
   /**
    * YotiConfig constructor.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   Config factory.
+   * @param Drupal\Core\File\FileSystemInterface $file_system
+   *   File system.
+   * @param Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager.
    */
-  public function __construct(ConfigFactoryInterface $config_factory) {
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    FileSystemInterface $file_system,
+    EntityTypeManagerInterface $entity_type_manager
+  ) {
     $this->configFactory = $config_factory;
+    $this->fileSystem = $file_system;
+    $this->fileStorage = $entity_type_manager->getStorage('file');
     $this->setConfig();
   }
 
@@ -44,11 +70,12 @@ class YotiConfig implements YotiConfigInterface {
 
     $pem = $settings->get('yoti_pem');
     $name = $contents = NULL;
-    if (isset($pem[0]) && ($file = File::load($pem[0]))) {
+
+    if (isset($pem[0]) && ($file = $this->fileStorage->load($pem[0]))) {
       $name = $file->getFileUri();
-      $contents = file_get_contents(\Drupal::service('file_system')->realpath($name));
+      $contents = file_get_contents($this->fileSystem->realpath($name));
     }
-    $this->config = [
+    $this->settings = [
       'yoti_app_id' => $settings->get('yoti_app_id'),
       'yoti_scenario_id' => $settings->get('yoti_scenario_id'),
       'yoti_sdk_id' => $settings->get('yoti_sdk_id'),
@@ -65,78 +92,78 @@ class YotiConfig implements YotiConfigInterface {
   /**
    * {@inheritdoc}
    */
-  public function getConfig() {
-    return $this->config;
+  public function getSettings() {
+    return $this->settings;
   }
 
   /**
    * {@inheritdoc}
    */
   public function getAppId() {
-    return $this->config['yoti_app_id'];
+    return $this->settings['yoti_app_id'];
   }
 
   /**
    * {@inheritdoc}
    */
   public function getScenarioId() {
-    return $this->config['yoti_scenario_id'];
+    return $this->settings['yoti_scenario_id'];
   }
 
   /**
    * {@inheritdoc}
    */
   public function getSdkId() {
-    return $this->config['yoti_sdk_id'];
+    return $this->settings['yoti_sdk_id'];
   }
 
   /**
    * {@inheritdoc}
    */
   public function getOnlyExisting() {
-    return $this->config['yoti_only_existing'];
+    return $this->settings['yoti_only_existing'];
   }
 
   /**
    * {@inheritdoc}
    */
   public function getSuccessUrl() {
-    return $this->config['yoti_success_url'];
+    return $this->settings['yoti_success_url'];
   }
 
   /**
    * {@inheritdoc}
    */
   public function getFailUrl() {
-    return $this->config['yoti_fail_url'];
+    return $this->settings['yoti_fail_url'];
   }
 
   /**
    * {@inheritdoc}
    */
   public function getUserEmail() {
-    return $this->config['yoti_user_email'];
+    return $this->settings['yoti_user_email'];
   }
 
   /**
    * {@inheritdoc}
    */
   public function getAgeVerification() {
-    return $this->config['yoti_age_verification'];
+    return $this->settings['yoti_age_verification'];
   }
 
   /**
    * {@inheritdoc}
    */
   public function getCompanyName() {
-    return $this->config['yoti_company_name'];
+    return $this->settings['yoti_company_name'];
   }
 
   /**
    * {@inheritdoc}
    */
   public function getPemContents() {
-    return $this->config['yoti_pem']['contents'];
+    return $this->settings['yoti_pem']['contents'];
   }
 
 }

--- a/yoti/src/YotiConfigInterface.php
+++ b/yoti/src/YotiConfigInterface.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\yoti;
+
+/**
+ * Interface YotiConfigInterface.
+ *
+ * @package Drupal\yoti
+ */
+interface YotiConfigInterface {
+
+  /**
+   * Yoti config data.
+   *
+   * @return array
+   *   Config data as array.
+   */
+  public function getConfig();
+
+  /**
+   * Yoti App ID.
+   *
+   * @return string
+   *   App ID.
+   */
+  public function getAppId();
+
+  /**
+   * Yoti Scenario ID.
+   *
+   * @return string
+   *   Scenario ID.
+   */
+  public function getScenarioId();
+
+  /**
+   * Yoti SDK ID.
+   *
+   * @return string
+   *   SDK ID.
+   */
+  public function getSdkId();
+
+  /**
+   * Only allow existing Drupal users to link their Yoti account.
+   *
+   * @return int
+   *   Flag to only link existing users.
+   */
+  public function getOnlyExisting();
+
+  /**
+   * Redirect users here if they successfully login with Yoti.
+   *
+   * @return string
+   *   Redirect URL.
+   */
+  public function getSuccessUrl();
+
+  /**
+   * Redirect users here if they were unable to login with Yoti.
+   *
+   * @return string
+   *   Redirect URL.
+   */
+  public function getFailUrl();
+
+  /**
+   * Attempt to link Yoti email address with Drupal account.
+   *
+   * @return int
+   *   Flag to link users based on email address.
+   */
+  public function getUserEmail();
+
+  /**
+   * Prevent users who have not passed age verification.
+   *
+   * @return int
+   *   Flag to prevent users that have not passed age verification.
+   */
+  public function getAgeVerification();
+
+  /**
+   * Company name to display to users.
+   *
+   * @return string
+   *   Company name.
+   */
+  public function getCompanyName();
+
+  /**
+   * Contents of the PEM file.
+   *
+   * @return string
+   *   PEM file contents.
+   */
+  public function getPemContents();
+
+}

--- a/yoti/src/YotiConfigInterface.php
+++ b/yoti/src/YotiConfigInterface.php
@@ -10,12 +10,12 @@ namespace Drupal\yoti;
 interface YotiConfigInterface {
 
   /**
-   * Yoti config data.
+   * Yoti settings data.
    *
    * @return array
-   *   Config data as array.
+   *   Settings data as array.
    */
-  public function getConfig();
+  public function getSettings();
 
   /**
    * Yoti App ID.

--- a/yoti/src/YotiHelper.php
+++ b/yoti/src/YotiHelper.php
@@ -702,7 +702,7 @@ class YotiHelper {
    *   Config data as array.
    */
   public static function getConfig() {
-    return Drupal::service('yoti.config')->getConfig();
+    return Drupal::service('yoti.config')->getSettings();
   }
 
   /**

--- a/yoti/src/YotiHelper.php
+++ b/yoti/src/YotiHelper.php
@@ -3,7 +3,6 @@
 namespace Drupal\yoti;
 
 use Drupal\Core\Url;
-use Drupal;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\user\Entity\User;
@@ -155,7 +154,7 @@ class YotiHelper {
    */
   public function link($currentUser = NULL) {
     if (!$currentUser) {
-      $currentUser = Drupal::currentUser();
+      $currentUser = \Drupal::currentUser();
     }
 
     $token = (!empty($_GET['token'])) ? $_GET['token'] : NULL;
@@ -294,7 +293,7 @@ class YotiHelper {
    */
   public static function getPathFullUrl($path = NULL) {
     // Get the root path including any subdomain.
-    $fullUrl = Drupal::request()->getBaseUrl();
+    $fullUrl = \Drupal::request()->getBaseUrl();
     if (!empty($path)) {
       // Add the target path to the root path.
       $fullUrl .= ($path[0] === '/') ? $path : '/' . $path;
@@ -307,7 +306,7 @@ class YotiHelper {
    * Unlink account from currently logged in.
    */
   public function unlink() {
-    $currentUser = Drupal::currentUser();
+    $currentUser = \Drupal::currentUser();
     // Unlink Yoti user.
     if (!$currentUser->isAnonymous()) {
       YotiUserModel::deleteYotiUserById($currentUser->id());
@@ -336,7 +335,7 @@ class YotiHelper {
    *   Yoti user details.
    */
   public static function storeYotiUser(ActivityDetails $activityDetails) {
-    $session = Drupal::service('session');
+    $session = \Drupal::service('session');
     if (!$session->isStarted()) {
       $session->migrate();
     }
@@ -350,7 +349,7 @@ class YotiHelper {
    *   Yoti user details.
    */
   public static function getYotiUserFromStore() {
-    $session = Drupal::service('session');
+    $session = \Drupal::service('session');
     if (!$session->isStarted()) {
       $session->migrate();
     }
@@ -361,7 +360,7 @@ class YotiHelper {
    * Remove Yoti user from the session.
    */
   public static function clearYotiUserStore() {
-    $session = Drupal::service('session');
+    $session = \Drupal::service('session');
     if (!$session->isStarted()) {
       $session->migrate();
     }
@@ -506,7 +505,7 @@ class YotiHelper {
    * @throws Exception
    */
   private function createUser(ActivityDetails $activityDetails) {
-    $language = Drupal::languageManager()->getCurrentLanguage()->getId();
+    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
     $user = User::create();
     $profile = $activityDetails->getProfile();
     $emailObj = $profile->getEmailAddress();
@@ -514,7 +513,7 @@ class YotiHelper {
 
     // If user has provided an email address and it's not in use then use it,
     // otherwise use Yoti generic email.
-    $isValidEmail = Drupal::service('email.validator')->isValid($userProvidedEmail);
+    $isValidEmail = \Drupal::service('email.validator')->isValid($userProvidedEmail);
     $userProvidedEmailCanBeUsed = $isValidEmail && !user_load_by_mail($userProvidedEmail);
     $userEmail = $userProvidedEmailCanBeUsed ? $userProvidedEmail : $this->generateEmail();
 
@@ -579,7 +578,7 @@ class YotiHelper {
       $content = $selfie->getValue()->getContent();
       $uploadDir = self::uploadDir(FALSE);
       if (!is_dir($uploadDir)) {
-        Drupal::service('file_system')->mkdir($uploadDir, 0777, TRUE);
+        \Drupal::service('file_system')->mkdir($uploadDir, 0777, TRUE);
       }
 
       $selfieFilename = md5("selfie_$userId" . time()) . '.png';
@@ -697,7 +696,7 @@ class YotiHelper {
    */
   public static function uploadDir($realPath = TRUE) {
     $yotiPemUploadDir = YotiHelper::YOTI_PEM_FILE_UPLOAD_LOCATION;
-    return $realPath ? Drupal::service('file_system')->realpath($yotiPemUploadDir) : $yotiPemUploadDir;
+    return $realPath ? \Drupal::service('file_system')->realpath($yotiPemUploadDir) : $yotiPemUploadDir;
   }
 
   /**
@@ -717,7 +716,7 @@ class YotiHelper {
    *   Config data as array.
    */
   public static function getConfig() {
-    return Drupal::service('yoti.config')->getSettings();
+    return \Drupal::service('yoti.config')->getSettings();
   }
 
   /**

--- a/yoti/src/YotiHelper.php
+++ b/yoti/src/YotiHelper.php
@@ -111,16 +111,31 @@ class YotiHelper {
    */
   public function __construct(
     EntityTypeManagerInterface $entityManager,
-    CacheTagsInvalidatorInterface $cacheTagsInvalidator,
-    LoggerChannelFactoryInterface $loggerFactory,
-    YotiSdkInterface $sdk,
-    YotiConfigInterface $config
+    CacheTagsInvalidatorInterface $cacheTagsInvalidator = NULL,
+    LoggerChannelFactoryInterface $loggerFactory = NULL,
+    YotiSdkInterface $sdk = NULL,
+    YotiConfigInterface $config = NULL
   ) {
     try {
       $this->userStorage = $entityManager->getStorage('user');
     }
     catch (\Exception $e) {
       YotiHelper::setFlash('Could not retrieve user data', 'error');
+    }
+
+    // Fetch services for backwards compatibility.
+    // All injected services will be required in the next major release.
+    if (is_null($cacheTagsInvalidator)) {
+      $cacheTagsInvalidator = \Drupal::service('cache_tags.invalidator');
+    }
+    if (is_null($loggerFactory)) {
+      $loggerFactory = \Drupal::service('logger.factory');
+    }
+    if (is_null($sdk)) {
+      $sdk = \Drupal::service('yoti.sdk');
+    }
+    if (is_null($config)) {
+      $config = \Drupal::service('yoti.config');
     }
 
     $this->config = $config;

--- a/yoti/src/YotiSdk.php
+++ b/yoti/src/YotiSdk.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\yoti;
+
+use Yoti\YotiClient;
+
+require_once __DIR__ . '/../sdk/boot.php';
+
+/**
+ * Class YotiSdk.
+ *
+ * @package Drupal\yoti
+ */
+class YotiSdk implements YotiSdkInterface {
+
+  /**
+   * Yoti Drupal SDK identifier.
+   */
+  const SDK_IDENTIFIER = 'Drupal';
+
+  /**
+   * Yoti plugin config data.
+   *
+   * @var \Drupal\yoti\YotiConfigInterface
+   */
+  private $config;
+
+  /**
+   * YotiSDK constructor.
+   *
+   * @param \Drupal\yoti\YotiConfigInterface $config
+   *   Yoti plugin config data.
+   */
+  public function __construct(YotiConfigInterface $config) {
+    $this->config = $config;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getClient() {
+    return new YotiClient(
+      $this->config->getSdkId(),
+      $this->config->getPemContents(),
+      YotiClient::DEFAULT_CONNECT_API,
+      self::SDK_IDENTIFIER
+    );
+  }
+
+}

--- a/yoti/src/YotiSdkInterface.php
+++ b/yoti/src/YotiSdkInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Drupal\yoti;
+
+/**
+ * Interface YotiSdk.
+ *
+ * @package Drupal\yoti
+ */
+interface YotiSdkInterface {
+
+  /**
+   * Creates a new YotiClient.
+   *
+   * @return \Yoti\YotiClient
+   *   Yoti Client.
+   */
+  public function getClient();
+
+}

--- a/yoti/tests/src/Functional/YotiBlockTest.php
+++ b/yoti/tests/src/Functional/YotiBlockTest.php
@@ -16,7 +16,7 @@ class YotiBlockTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = ['yoti', 'node', 'block', 'file'];
+  public static $modules = ['yoti', 'node', 'block'];
 
   /**
    * Setup tests.

--- a/yoti/tests/src/Functional/YotiBlockTest.php
+++ b/yoti/tests/src/Functional/YotiBlockTest.php
@@ -16,7 +16,7 @@ class YotiBlockTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = ['yoti', 'node', 'block'];
+  public static $modules = ['yoti', 'node', 'block', 'file'];
 
   /**
    * Setup tests.

--- a/yoti/tests/src/Unit/YotiConfigTest.php
+++ b/yoti/tests/src/Unit/YotiConfigTest.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Drupal\Tests\yoti\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\yoti\YotiConfig;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\file\FileInterface;
+
+/**
+ * @coversDefaultClass \Drupal\yoti\YotiConfig
+ *
+ * @group yoti
+ */
+class YotiConfigTest extends UnitTestCase {
+
+  /**
+   * Test file directory.
+   *
+   * @var string
+   */
+  private $tmpDir;
+
+  /**
+   * PEM file path.
+   *
+   * @var string
+   */
+  private $pemFilePath;
+
+  /**
+   * Yoti config.
+   *
+   * @var \Drupal\yoti\YotiConfig
+   */
+  private $config;
+
+  /**
+   * Yoti test settings.
+   *
+   * @var array
+   */
+  private $settings = [
+    'yoti_app_id' => 'app_id',
+    'yoti_scenario_id' => 'scenario_id',
+    'yoti_sdk_id' => 'sdk_id',
+    'yoti_only_existing' => 1,
+    'yoti_success_url' => '/user',
+    'yoti_fail_url' => '/',
+    'yoti_user_email' => 'user@example.com',
+    'yoti_age_verification' => 0,
+    'yoti_company_name' => 'company_name',
+    'yoti_pem' => [1],
+  ];
+
+  /**
+   * Create test YotiConfig object.
+   */
+  public function setup() {
+    parent::setup();
+
+    // Create tmp file directory.
+    $this->tmpDir = realpath(sys_get_temp_dir()) . DIRECTORY_SEPARATOR . 'drupal-yoti';
+    if (!is_dir($this->tmpDir)) {
+      mkdir($this->tmpDir, 0777, TRUE);
+    }
+
+    // Create test pem file.
+    $this->pemFilePath = $this->tmpDir . DIRECTORY_SEPARATOR . 'yoti_config_test.pem';
+    file_put_contents($this->pemFilePath, 'test_pem_content');
+
+    // Mock the config factory with Yoti settings.
+    $configFactory = $this->getConfigFactoryStub([
+      'yoti.settings' => $this->settings,
+    ]);
+
+    $this->config = new YotiConfig(
+      $configFactory,
+      $this->createMockFileSystem(),
+      $this->createMockEntityTypeManager()
+    );
+  }
+
+  /**
+   * Clean up test data.
+   */
+  public function teardown() {
+    parent::teardown();
+
+    // Remove test file.
+    if (is_file($this->pemFilePath)) {
+      unlink($this->pemFilePath);
+    }
+
+    // Remove test file directory.
+    if (is_dir($this->tmpDir)) {
+      rmdir($this->tmpDir);
+    }
+  }
+
+  /**
+   * @covers ::getSettings
+   */
+  public function testGetSettings() {
+    $expected_settings = $this->settings;
+    $expected_settings['yoti_pem'] = [
+      'name' => '/tmp/drupal-yoti/yoti_config_test.pem',
+      'contents' => 'test_pem_content',
+    ];
+    $this->assertEquals($expected_settings, $this->config->getSettings());
+  }
+
+  /**
+   * @covers ::getAppId
+   */
+  public function testGetAppId() {
+    $this->assertEquals($this->config->getAppId(), $this->settings['yoti_app_id']);
+  }
+
+  /**
+   * @covers ::getScenarioId
+   */
+  public function testGetScenarioId() {
+    $this->assertEquals($this->config->getScenarioId(), $this->settings['yoti_scenario_id']);
+  }
+
+  /**
+   * @covers ::getSdkId
+   */
+  public function testGetSdkId() {
+    $this->assertEquals($this->config->getSdkId(), $this->settings['yoti_sdk_id']);
+  }
+
+  /**
+   * @covers ::getOnlyExisting
+   */
+  public function testGetOnlyExisting() {
+    $this->assertEquals($this->config->getOnlyExisting(), $this->settings['yoti_only_existing']);
+  }
+
+  /**
+   * @covers ::getSuccessUrl
+   */
+  public function testGetSuccessUrl() {
+    $this->assertEquals($this->config->getSuccessUrl(), $this->settings['yoti_success_url']);
+  }
+
+  /**
+   * @covers ::getFailUrl
+   */
+  public function testGetFailUrl() {
+    $this->assertEquals($this->config->getFailUrl(), $this->settings['yoti_fail_url']);
+  }
+
+  /**
+   * @covers ::getUserEmail
+   */
+  public function testGetUserEmail() {
+    $this->assertEquals($this->config->getUserEmail(), $this->settings['yoti_user_email']);
+  }
+
+  /**
+   * @covers ::getAgeVerification
+   */
+  public function testGetAgeVerification() {
+    $this->assertEquals($this->config->getAgeVerification(), $this->settings['yoti_age_verification']);
+  }
+
+  /**
+   * @covers ::getCompanyName
+   */
+  public function testGetCompanyName() {
+    $this->assertEquals($this->config->getCompanyName(), $this->settings['yoti_company_name']);
+  }
+
+  /**
+   * @covers ::getPemContents
+   */
+  public function testGetPemContents() {
+    $this->assertEquals($this->config->getPemContents(), 'test_pem_content');
+  }
+
+  /**
+   * Mock the file system.
+   *
+   * @return \Drupal\Core\File\FileSystemInterface
+   *   File system.
+   */
+  private function createMockFileSystem() {
+    $file_system = $this->createMock(FileSystemInterface::class);
+    $file_system
+      ->method('realpath')
+      ->willReturn($this->pemFilePath);
+
+    return $file_system;
+  }
+
+  /**
+   * Mock the entity type manager.
+   *
+   * @return \Drupal\Core\Entity\EntityTypeManagerInterface
+   *   Entity type manager.
+   */
+  private function createMockEntityTypeManager() {
+    $file = $this->createMock(FileInterface::class);
+    $file
+      ->method('getFileUri')
+      ->willReturn($this->pemFilePath);
+
+    $file_storage = $this->createMock(EntityStorageInterface::class);
+    $file_storage
+      ->method('load')
+      ->willReturn($file);
+
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager
+      ->method('getStorage')
+      ->willReturn($file_storage);
+
+    return $entity_type_manager;
+  }
+
+}

--- a/yoti/tests/src/Unit/YotiHelperTest.php
+++ b/yoti/tests/src/Unit/YotiHelperTest.php
@@ -2,17 +2,33 @@
 
 namespace Drupal\Tests\yoti\Unit;
 
-use Drupal\Tests\UnitTestCase;
-use Drupal\yoti\YotiHelper;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
-use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\Core\DependencyInjection\ContainerBuilder;
-use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityStorageInterface;
-use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Database\Query\Delete;
+use Drupal\Core\Database\Query\Select;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Tests\UnitTestCase;
+use Drupal\user\UserInterface;
+use Drupal\yoti\YotiConfigInterface;
+use Drupal\yoti\YotiHelper;
+use Drupal\yoti\YotiSdkInterface;
+use Egulias\EmailValidator\EmailValidatorInterface;
+use Psr\Log\LoggerInterface;
+use Yoti\YotiClient;
+use Yoti\Entity\Profile;
+use Yoti\Exception\ActivityDetailsException;
+use Yoti\ActivityDetails;
+
+require_once __DIR__ . '/../../../sdk/boot.php';
 
 /**
  * @coversDefaultClass \Drupal\yoti\YotiHelper
@@ -25,14 +41,7 @@ class YotiHelperTest extends UnitTestCase {
    * Setup for YotiHelper tests.
    */
   public function setUp() {
-    // Setup container to handle situations where dependencies
-    // haven't been injected.
-    $container = new ContainerBuilder();
-    $container->set('config.factory', $this->createMockConfigFactory());
-    $container->set('current_user', $this->getMock(AccountProxyInterface::class));
-    $container->set('messenger', $this->getMock(MessengerInterface::class));
-    $container->set('database', $this->createMockDatabase());
-    \Drupal::setContainer($container);
+    $this->createContainer();
   }
 
   /**
@@ -41,12 +50,29 @@ class YotiHelperTest extends UnitTestCase {
    */
   public function testLinkInvalidToken() {
     // Cache should not be invalidated if invalid token is provided.
-    $cacheTagsInvalidator = $this->getMock(CacheTagsInvalidatorInterface::class);
+    $cacheTagsInvalidator = $this->createMock(CacheTagsInvalidatorInterface::class);
     $cacheTagsInvalidator
       ->expects($this->exactly(0))
       ->method('invalidateTags');
 
-    $helper = new YotiHelper($this->createMockEntityTypeManager(), $cacheTagsInvalidator);
+    // Throw exception to simulate a share failure.
+    $client = $this->createMock(YotiClient::class);
+    $client
+      ->method('getActivityDetails')
+      ->will($this->throwException(new ActivityDetailsException()));
+
+    $sdk = $this->createMock(YotiSdkInterface::class);
+    $sdk
+      ->method('getClient')
+      ->willReturn($client);
+
+    $helper = new YotiHelper(
+      $this->createMockEntityTypeManager(),
+      $cacheTagsInvalidator,
+      $this->createMock(LoggerChannelFactoryInterface::class),
+      $sdk,
+      $this->createMock(YotiConfigInterface::class)
+    );
 
     // Attempt link with no token.
     $result = $helper->link();
@@ -59,18 +85,85 @@ class YotiHelperTest extends UnitTestCase {
   }
 
   /**
+   * @covers ::link
+   * @backupGlobals enabled
+   */
+  public function testUserSaveFailure() {
+    // Set current user to anonymous so that a new user is created.
+    $current_user = $this->createMock(AccountProxyInterface::class);
+    $current_user
+      ->method('isAnonymous')
+      ->willReturn(TRUE);
+
+    // Return FALSE when new user is saved.
+    $user = $this->createMock(UserInterface::class);
+    $user
+      ->method('save')
+      ->willReturn(FALSE);
+    $entity_storage = $this->createMockEntityStorage($user);
+
+    $this->setContainerService(
+      'entity_type.manager',
+      $this->createMockEntityTypeManagerStorage($entity_storage)
+    );
+
+    // Expect error to be logged.
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger
+      ->expects($this->once())
+      ->method('error')
+      ->with($this->equalTo('Could not save Yoti user'));
+
+    $helper = new YotiHelper(
+      $this->createMockEntityTypeManager(),
+      $this->createMock(CacheTagsInvalidatorInterface::class),
+      $this->createMockLoggerFactory($logger),
+      $this->createMockSdk(),
+      $this->createMock(YotiConfigInterface::class)
+    );
+
+    $_GET['token'] = 'test_token';
+    $result = $helper->link($current_user);
+    $this->assertFalse($result);
+  }
+
+  /**
    * @covers ::unlink
    */
   public function testUnlinkCacheInvalidation() {
     // Cache should be invalidated when user is unlinked.
-    $cacheTagsInvalidator = $this->getMock(CacheTagsInvalidatorInterface::class);
+    $cacheTagsInvalidator = $this->createMock(CacheTagsInvalidatorInterface::class);
     $cacheTagsInvalidator
       ->expects($this->once())
       ->method('invalidateTags')
       ->with($this->equalTo(['tag:1', 'tag:2']));
 
-    $helper = new YotiHelper($this->createMockEntityTypeManager(), $cacheTagsInvalidator);
+    $helper = new YotiHelper(
+      $this->createMockEntityTypeManager(),
+      $cacheTagsInvalidator,
+      $this->createMock(LoggerChannelFactoryInterface::class),
+      $this->createMock(YotiSdkInterface::class),
+      $this->createMock(YotiConfigInterface::class)
+    );
+
     $helper->unlink();
+  }
+
+  /**
+   * Creates mock entity storage.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Mocked entity.
+   *
+   * @return \Drupal\Core\Entity\EntityStorageInterface
+   *   Mocked entity type manager
+   */
+  private function createMockEntityStorage(EntityInterface $entity) {
+    $entity_storage = $this->createMock(EntityStorageInterface::class);
+    $entity_storage
+      ->method('create')
+      ->willReturn($entity);
+    return $entity_storage;
   }
 
   /**
@@ -81,7 +174,7 @@ class YotiHelperTest extends UnitTestCase {
    */
   private function createMockEntityTypeManager() {
     // Mock user storage.
-    $user = $this->getMock(EntityInterface::class);
+    $user = $this->createMock(EntityInterface::class);
     $user
       ->method('id')
       ->willReturn('2');
@@ -89,13 +182,13 @@ class YotiHelperTest extends UnitTestCase {
       ->method('getCacheTagsToInvalidate')
       ->willReturn(['tag:1', 'tag:2']);
 
-    $userStorage = $this->getMock(EntityStorageInterface::class);
+    $userStorage = $this->createMock(EntityStorageInterface::class);
     $userStorage
       ->method('load')
       ->willReturn($user);
 
     // Mock entity type manager.
-    $entityManager = $this->getMock(EntityTypeManagerInterface::class);
+    $entityManager = $this->createMock(EntityTypeManagerInterface::class);
     $entityManager
       ->method('getStorage')
       ->will($this->returnValueMap([
@@ -103,6 +196,24 @@ class YotiHelperTest extends UnitTestCase {
       ]));
 
     return $entityManager;
+  }
+
+  /**
+   * Create mock logger factory.
+   *
+   * @param \Psr\Log\LoggerInterface $logger
+   *   Mocked logger.
+   *
+   * @return \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   *   Logger factory.
+   */
+  private function createMockLoggerFactory(LoggerInterface $logger) {
+    $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $loggerFactory
+      ->method('get')
+      ->willReturn($logger);
+
+    return $loggerFactory;
   }
 
   /**
@@ -115,7 +226,7 @@ class YotiHelperTest extends UnitTestCase {
     // Mock database connextion.
     $database = $this->getMockBuilder(Connection::class)
       ->disableOriginalConstructor()
-      ->setMethods(['delete'])
+      ->setMethods(['delete', 'select', 'escapeLike'])
       ->getMockForAbstractClass();
 
     // Mock delete query.
@@ -130,6 +241,20 @@ class YotiHelperTest extends UnitTestCase {
     $database
       ->method('delete')
       ->willReturn($deleteQuery);
+
+    // Mock the select query.
+    $selectQuery = $this->getMockBuilder(Select::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['condition', 'execute', 'fetchAll', 'escapeLike'])
+      ->getMockForAbstractClass();
+    $selectQuery
+      ->method('fetchAll')
+      ->willReturn([]);
+    $selectQuery->method('execute')
+      ->willReturn($selectQuery);
+    $database
+      ->method('select')
+      ->willReturn($selectQuery);
 
     return $database;
   }
@@ -158,6 +283,139 @@ class YotiHelperTest extends UnitTestCase {
         ],
       ],
     ]);
+  }
+
+  /**
+   * Creates mock email validator.
+   *
+   * @return \Egulias\EmailValidator\EmailValidatorInterface
+   *   Email validator.
+   */
+  private function createMockEmailValidator() {
+    $email_validator = $this->createMock(EmailValidatorInterface::class);
+    $email_validator
+      ->method('isValid')
+      ->willReturn(TRUE);
+    return $email_validator;
+  }
+
+  /**
+   * Creates mock entity type manager.
+   *
+   * @param \Drupal\Core\Entity\EntityStorageInterface $entity_storage
+   *   Mocked entity storage.
+   *
+   * @return \Drupal\Core\Entity\EntityTypeManagerInterface
+   *   Entity type manager.
+   */
+  private function createMockEntityTypeManagerStorage(EntityStorageInterface $entity_storage) {
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager
+      ->method('getStorage')
+      ->willReturn($entity_storage);
+
+    return $entity_type_manager;
+  }
+
+  /**
+   * Creates mock language manager.
+   *
+   * @return \Drupal\Core\Language\LanguageManagerInterface
+   *   Language manager.
+   */
+  private function createMockLanguageManager() {
+    $language = $this->createMock(LanguageInterface::class);
+    $language
+      ->method('getId')
+      ->willReturn('en');
+
+    $language_manager = $this->createMock(LanguageManagerInterface::class);
+    $language_manager
+      ->method('getCurrentLanguage')
+      ->willReturn($language);
+
+    return $language_manager;
+  }
+
+  /**
+   * Setup container to handle dependencies that haven't been injected.
+   */
+  private function createContainer() {
+    $container = new ContainerBuilder();
+    $container->set('config.factory', $this->createMockConfigFactory());
+    $container->set('current_user', $this->createMock(AccountProxyInterface::class));
+    $container->set('messenger', $this->createMock(MessengerInterface::class));
+    $container->set('database', $this->createMockDatabase());
+    $container->set('email.validator', $this->createMockEmailValidator());
+    $container->set('entity_type.repository', $this->createMock(EntityTypeRepositoryInterface::class));
+    $container->set('language_manager', $this->createMockLanguageManager());
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Creates mock SDK.
+   *
+   * @return \Drupal\yoti\YotiSdkInterface
+   *   Yoti SDK service.
+   */
+  private function createMockSdk() {
+    $profile = $this->createMock(Profile::class);
+    $profile
+      ->method('getAttributes')
+      ->willReturn([]);
+    $profile
+      ->method('getAgeVerifications')
+      ->willReturn([]);
+
+    $activityDetails = $this->createMock(ActivityDetails::class);
+    $activityDetails
+      ->method('getProfile')
+      ->willReturn($profile);
+
+    $client = $this->createMock(YotiClient::class);
+    $client
+      ->method('getActivityDetails')
+      ->willReturn($activityDetails);
+
+    $sdk = $this->createMock(YotiSdkInterface::class);
+    $sdk
+      ->method('getClient')
+      ->willReturn($client);
+
+    return $sdk;
+  }
+
+  /**
+   * Sets a service.
+   *
+   * @param string $id
+   *   The service identifier.
+   * @param object $service
+   *   The service instance.
+   */
+  private function setContainerService($id, $service) {
+    $container = \Drupal::getContainer();
+    $container->set($id, $service);
+    \Drupal::setContainer($container);
+  }
+
+}
+
+/**
+ * Mock global functions.
+ */
+namespace Drupal\yoti;
+
+if (!function_exists('user_load_by_mail')) {
+
+  /**
+   * Mock user_load_by_mail().
+   *
+   * @return bool
+   *   True if a user with mail exists.
+   */
+  function user_load_by_mail() {
+    return FALSE;
   }
 
 }

--- a/yoti/tests/src/Unit/YotiSdkTest.php
+++ b/yoti/tests/src/Unit/YotiSdkTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\Tests\yoti\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\yoti\YotiSdk;
+use Drupal\yoti\YotiConfigInterface;
+use Yoti\YotiClient;
+
+/**
+ * @coversDefaultClass \Drupal\yoti\YotiSdk
+ *
+ * @group yoti
+ */
+class YotiSdkTest extends UnitTestCase {
+
+  /**
+   * Yoti config.
+   *
+   * @var \Drupal\yoti\YotiConfigInterface
+   */
+  private $config;
+
+  /**
+   * Setup Yoti SDK tests.
+   */
+  public function setup() {
+    parent::setup();
+
+    $config = $this->createMock(YotiConfigInterface::class);
+    $config
+      ->method('getSdkId')
+      ->willReturn('test_sdk_id');
+
+    openssl_pkey_export(openssl_pkey_new(), $pem_contents);
+    $config
+      ->method('getPemContents')
+      ->willReturn($pem_contents);
+
+    $this->config = $config;
+  }
+
+  /**
+   * @covers ::getClient
+   */
+  public function testGetClient() {
+    $sdk = new YotiSdk($this->config);
+    $this->assertInstanceOf(YotiClient::class, $sdk->getClient());
+  }
+
+}

--- a/yoti/yoti.info.yml
+++ b/yoti/yoti.info.yml
@@ -1,5 +1,6 @@
 name: 'Yoti'
-dependencies: {  }
+dependencies:
+  - drupal:file
 description: 'Let Yoti users quickly register on your site. Note: Need to enable module in module manager'
 core: 8.x
 package: Authentication

--- a/yoti/yoti.services.yml
+++ b/yoti/yoti.services.yml
@@ -4,7 +4,7 @@ services:
     arguments: ['@yoti.config']
   yoti.config:
     class: Drupal\yoti\YotiConfig
-    arguments: ['@config.factory']
+    arguments: ['@config.factory', '@file_system', '@entity_type.manager']
   yoti.helper:
     class: Drupal\yoti\YotiHelper
     arguments: ['@entity_type.manager', '@cache_tags.invalidator', '@logger.factory', '@yoti.sdk', '@yoti.config']

--- a/yoti/yoti.services.yml
+++ b/yoti/yoti.services.yml
@@ -1,4 +1,10 @@
 services:
+  yoti.sdk:
+    class: Drupal\yoti\YotiSdk
+    arguments: ['@yoti.config']
+  yoti.config:
+    class: Drupal\yoti\YotiConfig
+    arguments: ['@config.factory']
   yoti.helper:
     class: Drupal\yoti\YotiHelper
-    arguments: ['@entity_type.manager', '@cache_tags.invalidator']
+    arguments: ['@entity_type.manager', '@cache_tags.invalidator', '@logger.factory', '@yoti.sdk', '@yoti.config']


### PR DESCRIPTION
- Logging exception message when user creation fails (injecting `LoggerChannelFactoryInterface` into `YotiHelper`)
- Display user friendly message when user creation fails. 
- Split `yoti.sdk` and `yoti.config` services from `YotiHelper` class:
  - `yoti.sdk` service allows the SDK to be swapped and also makes testing much easier as it can be mocked and injected into the YotiHelper.
  - `yoti.config` services is used by both the `yoti.sdk` and `yoti.helper` services - I've added getters for the config settings so that we can control the returned values in one place.
- Added missing `drupal:file` dependency (this is required to save the pem file) - functional tests highlighted that this was missing
- Standardised use of `\Drupal` (as per core see https://www.drupal.org/project/drupal/issues/2053489)
- Fetching services in `YotiHelper` constructor for backwards compatibility
