### PR TITLE
SDK-797: Use form API for user login checkbox

### DIFF
--- a/yoti/src/Form/YotiUserLoginForm.php
+++ b/yoti/src/Form/YotiUserLoginForm.php
@@ -20,24 +20,35 @@ class YotiUserLoginForm extends UserLoginForm {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = YotiHelper::getConfig();
 
-    $companyName = (!empty($config['yoti_company_name'])) ? $config['yoti_company_name'] : 'Drupal';
+    $company_name = (!empty($config['yoti_company_name'])) ? $config['yoti_company_name'] : 'Drupal';
 
-    $form['yoti_nolink'] = [
+    $form['yoti_login_message'] = [
+      '#type' => 'fieldset',
       '#weight' => -1000,
-      '#type' => 'inline_template',
-      '#template' => '{{ somecontent | raw }}',
-      '#default_value' => \Drupal::config('yoti_nolink')->get(),
-      '#context' => [
-        'somecontent' => '<div class="form-item form-type-checkbox form-item-yoti-link messages warning" style="margin: 0 0 15px 0">
-                    <div><b>Warning: You are about to link your ' . $companyName . ' account to your Yoti account. If you don\'t want this to happen, tick the checkbox below.</b></div>
-                    <input type="checkbox" id="edit-yoti-link" name="yoti_nolink" value="1" class="form-checkbox"' . (!empty($form_state->get('yoti_nolink')) ? ' checked="checked"' : '') . '>
-                    <label class="option" for="edit-yoti-link">Don\'t link my Yoti account</label>
-                </div>',
+      '#collapsible' => FALSE,
+      '#collapsed' => FALSE,
+      '#attributes' => [
+        'class' => ['messages', 'warning'],
       ],
     ];
 
-    $form['name']['#title'] = "Your {$companyName} Username";
-    $form['pass']['#title'] = "Your {$companyName} Password";
+    $form['yoti_login_message']['text'] = [
+      '#type' => 'inline_template',
+      '#template' => "
+        <div>
+          <b>Warning: You are about to link your {{ company_name }} account to your Yoti account.
+          If you don't want this to happen, tick the checkbox below.</b>
+        </div>",
+      '#context' => [
+        'company_name' => $company_name,
+      ],
+    ];
+
+    $form['yoti_login_message']['yoti_nolink'] = [
+      '#type' => 'checkbox',
+      '#title' => t("Don't link my Yoti account"),
+      '#default_value' => $form_state->get('yoti_nolink'),
+    ];
 
     return parent::buildForm($form, $form_state);
   }

--- a/yoti/tests/src/Functional/YotiUserLoginFormTest.php
+++ b/yoti/tests/src/Functional/YotiUserLoginFormTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\Tests\yoti\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests the Yoti user login form.
+ *
+ * @group yoti
+ */
+class YotiUserLoginFormTest extends BrowserTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = ['yoti'];
+
+  /**
+   * Authenticated users can view login form.
+   */
+  public function testAuthenticatedUser() {
+    $testUser = $this->drupalCreateUser([
+      'access content',
+    ]);
+    $this->drupalLogin($testUser);
+
+    $this->drupalGet('yoti/register');
+
+    $assert = $this->assertSession();
+    $assert->statusCodeEquals(403);
+  }
+
+  /**
+   * Anonymous users can view login form.
+   */
+  public function testAnonymousUser() {
+    $this->drupalGet('yoti/register');
+
+    $assert = $this->assertSession();
+    $assert->statusCodeEquals(200);
+
+    $assert->pageTextContains('Warning: You are about to link your Drupal account to your Yoti account.');
+    $assert->pageTextContains("If you don't want this to happen, tick the checkbox below.");
+    $assert->elementExists('css', "input[type='checkbox'][name='yoti_nolink']");
+  }
+
+}

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -140,7 +140,7 @@ function yoti_user_login($account) {
   $activityDetails = YotiHelper::getYotiUserFromStore();
   if ($activityDetails && empty($_SESSION['yoti_nolink']) && !isset($_REQUEST['yoti_nolink'])) {
     // Link user account.
-    $helper = new YotiHelper(\Drupal::entityTypeManager());
+    $helper = \Drupal::service('yoti.helper');
     $helper->createYotiUser($account->id(), $activityDetails);
   }
 

--- a/yoti/yoti.routing.yml
+++ b/yoti/yoti.routing.yml
@@ -13,7 +13,7 @@ yoti.register:
     _form: '\Drupal\yoti\Form\YotiUserLoginForm'
     _title: 'User Login'
   requirements:
-    _permission: 'access content'
+    _user_is_logged_in: 'FALSE'
   options:
     no_cache: TRUE
 


### PR DESCRIPTION
- Prevent logged in users being able to visit the custom login form
- Using fieldset to group message and opt-out checkbox
- Separated variables from login message template
- Added test coverage for access and message