### PR TITLE
SDK-929: Deprecate helper getters

### DIFF
--- a/yoti/src/Controller/YotiStartController.php
+++ b/yoti/src/Controller/YotiStartController.php
@@ -24,7 +24,7 @@ class YotiStartController extends ControllerBase {
   public function link() {
     /** @var \Drupal\yoti\YotiHelper $helper */
     $helper = \Drupal::service('yoti.helper');
-    $config = YotiHelper::getConfig();
+    $config = \Drupal::service('yoti.config');
 
     // If no token is given check if we are in mock request mode.
     if (!array_key_exists('token', $_GET)) {
@@ -33,14 +33,14 @@ class YotiStartController extends ControllerBase {
 
     $result = $helper->link();
     if (!$result) {
-      $failedURL = YotiHelper::getPathFullUrl($config['yoti_fail_url']);
+      $failedURL = YotiHelper::getPathFullUrl($config->getFailUrl());
       return new TrustedRedirectResponse($failedURL);
     }
     elseif ($result instanceof RedirectResponse) {
       return $result;
     }
 
-    $successUrl = YotiHelper::getPathFullUrl($config['yoti_success_url']);
+    $successUrl = YotiHelper::getPathFullUrl($config->getSuccessUrl());
     return new TrustedRedirectResponse($successUrl);
   }
 

--- a/yoti/src/Form/YotiUserLoginForm.php
+++ b/yoti/src/Form/YotiUserLoginForm.php
@@ -4,7 +4,6 @@ namespace Drupal\yoti\Form;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\user\Form\UserLoginForm;
-use Drupal\yoti\YotiHelper;
 
 /**
  * Class YotiUserLoginForm.
@@ -18,9 +17,9 @@ class YotiUserLoginForm extends UserLoginForm {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $config = YotiHelper::getConfig();
+    $config = \Drupal::service('yoti.config');
 
-    $company_name = (!empty($config['yoti_company_name'])) ? $config['yoti_company_name'] : 'Drupal';
+    $company_name = (!empty($config->getCompanyName())) ? $config->getCompanyName() : 'Drupal';
 
     $form['yoti_login_message'] = [
       '#type' => 'fieldset',

--- a/yoti/src/Plugin/Block/YotiBlock.php
+++ b/yoti/src/Plugin/Block/YotiBlock.php
@@ -35,8 +35,8 @@ class YotiBlock extends BlockBase {
     $user = \Drupal::currentUser();
 
     // No config? no button.
-    $config = YotiHelper::getConfig();
-    if (!$config) {
+    $config = \Drupal::service('yoti.config');
+    if (!$config->getSettings()) {
       return [];
     }
 
@@ -64,8 +64,8 @@ class YotiBlock extends BlockBase {
 
     return [
       '#theme' => 'yoti_button',
-      '#app_id' => $config['yoti_app_id'],
-      '#scenario_id' => $config['yoti_scenario_id'],
+      '#app_id' => $config->getAppId(),
+      '#scenario_id' => $config->getScenarioId(),
       '#button_text' => $button_text,
       '#is_linked' => $is_linked,
       '#is_staging' => $is_staging,

--- a/yoti/src/YotiHelper.php
+++ b/yoti/src/YotiHelper.php
@@ -9,7 +9,6 @@ use Drupal\user\Entity\User;
 use Drupal\yoti\Models\YotiUserModel;
 use Exception;
 use Yoti\ActivityDetails;
-use Yoti\YotiClient;
 use Yoti\Entity\Profile;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
@@ -737,6 +736,8 @@ class YotiHelper {
   /**
    * Yoti config data.
    *
+   * @deprecated use `yoti.config` service instead.
+   *
    * @return array
    *   Config data as array.
    */
@@ -747,16 +748,13 @@ class YotiHelper {
   /**
    * Get Yoti Dashboard app URL.
    *
+   * @deprecated use `yoti.sdk` service instead.
+   *
    * @return null|string
    *   Yoti App URL.
    */
   public static function getLoginUrl() {
-    $config = self::getConfig();
-    if (empty($config->getAppId())) {
-      return NULL;
-    }
-
-    return YotiClient::getLoginUrl($config->getAppId());
+    return \Drupal::service('yoti.sdk')->getLoginUrl();
   }
 
   /**

--- a/yoti/src/YotiSdk.php
+++ b/yoti/src/YotiSdk.php
@@ -47,4 +47,13 @@ class YotiSdk implements YotiSdkInterface {
     );
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getLoginUrl() {
+    if ($appId = $this->config->getAppId()) {
+      return YotiClient::getLoginUrl($appId);
+    }
+  }
+
 }

--- a/yoti/src/YotiSdkInterface.php
+++ b/yoti/src/YotiSdkInterface.php
@@ -17,4 +17,12 @@ interface YotiSdkInterface {
    */
   public function getClient();
 
+  /**
+   * Get Yoti Dashboard app URL.
+   *
+   * @return null|string
+   *   Yoti App URL.
+   */
+  public function getLoginUrl();
+
 }

--- a/yoti/tests/src/Unit/YotiHelperTest.php
+++ b/yoti/tests/src/Unit/YotiHelperTest.php
@@ -189,6 +189,13 @@ class YotiHelperTest extends YotiUnitTestBase {
   }
 
   /**
+   * @covers ::getLoginUrl
+   */
+  public function testGetLoginUrl() {
+    $this->assertEquals('https://www.yoti.com/connect/test_app_id', YotiHelper::getLoginUrl());
+  }
+
+  /**
    * Creates mock entity storage.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
@@ -412,6 +419,7 @@ class YotiHelperTest extends YotiUnitTestBase {
     $container->set('entity_type.repository', $this->createMock(EntityTypeRepositoryInterface::class));
     $container->set('language_manager', $this->createMockLanguageManager());
     $container->set('file_system', $this->createMockFileSystem());
+    $container->set('yoti.sdk', $this->createMockSdk());
     \Drupal::setContainer($container);
   }
 
@@ -493,6 +501,9 @@ class YotiHelperTest extends YotiUnitTestBase {
     $sdk
       ->method('getClient')
       ->willReturn($client);
+    $sdk
+      ->method('getLoginUrl')
+      ->willReturn('https://www.yoti.com/connect/test_app_id');
 
     return $sdk;
   }

--- a/yoti/tests/src/Unit/YotiSdkTest.php
+++ b/yoti/tests/src/Unit/YotiSdkTest.php
@@ -30,6 +30,9 @@ class YotiSdkTest extends YotiUnitTestBase {
     $config
       ->method('getSdkId')
       ->willReturn('test_sdk_id');
+    $config
+      ->method('getAppId')
+      ->willReturn('test_app_id');
 
     openssl_pkey_export(openssl_pkey_new(), $pem_contents);
     $config
@@ -45,6 +48,14 @@ class YotiSdkTest extends YotiUnitTestBase {
   public function testGetClient() {
     $sdk = new YotiSdk($this->config);
     $this->assertInstanceOf(YotiClient::class, $sdk->getClient());
+  }
+
+  /**
+   * @covers ::getLoginUrl
+   */
+  public function testGetLoginUrl() {
+    $sdk = new YotiSdk($this->config);
+    $this->assertEquals('https://www.yoti.com/connect/test_app_id', $sdk->getLoginUrl());
   }
 
 }


### PR DESCRIPTION
- Deprecated `YotiHelper::getConfig()`
- Using `yoti.config` service in place of `YotiHelper::getConfig()`
- Moved `YotiHelper::getLoginUrl()` to `yoti.sdk` service