### PR TITLE
SDK-805: Block Cache

### DIFF
--- a/yoti/YotiHelper.php
+++ b/yoti/YotiHelper.php
@@ -703,10 +703,11 @@ class YotiHelper {
    */
   public static function getYotiUserProfile($userUid) {
     $userProfileArr = NULL;
+    $userUid = (int) $userUid;
     if ($userUid) {
       $userProfileArr = db_select(YotiHelper::YOTI_USER_TABLE_NAME, 'u')
         ->fields('u')
-        ->condition('uid', (int) $userUid)
+        ->condition('uid', $userUid)
         ->range(0, 1)
         ->execute()
         ->fetchAssoc();

--- a/yoti/YotiHelper.php
+++ b/yoti/YotiHelper.php
@@ -702,11 +702,14 @@ class YotiHelper {
    *   Yoti user profile data.
    */
   public static function getYotiUserProfile($userUid) {
-    $tableName = YotiHelper::YOTI_USER_TABLE_NAME;
     $userProfileArr = NULL;
-    $userUid = (int) $userUid;
     if ($userUid) {
-      $userProfileArr = db_query("SELECT * from `{$tableName}` WHERE uid=$userUid Limit 1")->fetchAssoc();
+      $userProfileArr = db_select(YotiHelper::YOTI_USER_TABLE_NAME, 'u')
+        ->fields('u')
+        ->condition('uid', (int) $userUid)
+        ->range(0, 1)
+        ->execute()
+        ->fetchAssoc();
     }
     return $userProfileArr;
   }

--- a/yoti/templates/yoti-button.tpl.php
+++ b/yoti/templates/yoti-button.tpl.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * Default theme implementation to display a Yoti button.
+ *
+ * Available variables:
+ * - $app_id: Yoti App ID.
+ * - $scenario_id: Yoti Scenario ID.
+ * - $button_text: Button Text.
+ * - $is_linked: TRUE if the account is linked.
+ */
+?>
+<div class="yoti-connect">
+  <?php if($is_linked): ?>
+    <strong>Yoti</strong> Linked
+  <?php else: ?>
+    <span
+      data-yoti-application-id="<?php print $app_id; ?>"
+      data-yoti-type="inline"
+      data-yoti-scenario-id="<?php print $scenario_id; ?>"
+      data-size="small">
+        <?php print $button_text; ?>
+    </span>
+  <?php endif; ?>
+</div>

--- a/yoti/tests/yoti.test
+++ b/yoti/tests/yoti.test
@@ -170,9 +170,10 @@ class YotiTest extends DrupalWebTestCase {
 
     // Check that SDK script is included on page.
     $this->assertElementByXpath(
-      '//head/script[@src=:src]',
+      '//head/script[contains(@src,:base_url)][contains(@src,:ext)]',
       array(
-        ':src' => 'https://sdk.yoti.com/clients/browser.2.1.0.js',
+        ':base_url' => 'https://sdk.yoti.com/clients/browser',
+        ':ext' => '.js',
       ),
       'Check SDK browser JS is present.'
     );

--- a/yoti/tests/yoti.test
+++ b/yoti/tests/yoti.test
@@ -94,6 +94,9 @@ class YotiTest extends DrupalWebTestCase {
     // Configure module.
     $this->configureModule();
 
+    // Enable block caching.
+    variable_set('block_cache', TRUE);
+
     // Create a linked user.
     $this->linkedUser = $this->drupalCreateUser();
     db_insert(YotiHelper::YOTI_USER_TABLE_NAME)->fields([
@@ -101,6 +104,9 @@ class YotiTest extends DrupalWebTestCase {
       'identifier' => 'some-remember-me-id',
       'data' => serialize(array()),
     ])->execute();
+
+    // Create an unlinked user.
+    $this->unlinkedUser = $this->drupalCreateUser();
   }
 
   /**
@@ -162,20 +168,36 @@ class YotiTest extends DrupalWebTestCase {
       'Check button markup is correct.'
     );
 
+    // Check that SDK script is included on page.
+    $this->assertElementByXpath(
+      '//head/script[@src=:src]',
+      array(
+        ':src' => 'https://sdk.yoti.com/clients/browser.2.1.0.js',
+      ),
+      'Check SDK browser JS is present.'
+    );
+
+    // Check that button CSS is included on page.
+    $this->assertRaw('/yoti/css/yoti.css');
+
+    // Check that SDK script is included on page.
+    $this->assertElementByXpath(
+      '//body//script[contains(text(),:script)]',
+      array(
+        ':script' => '_ybg.init();',
+      ),
+      'Check SDK inline init script is present.'
+    );
+
     // Check that linked users see linked message.
     $this->drupalLogin($this->linkedUser);
-
     $this->drupalGet('<front>');
     $this->assertText('Yoti Linked');
-  }
 
-  /**
-   * Test Yoti Block Info.
-   */
-  public function testBlockInfo() {
-    $info = module_invoke('yoti', 'block_info');
-    $this->assertEqual(DRUPAL_CACHE_PER_USER, $info['yoti_link']['cache'], t('Cache is set to DRUPAL_CACHE_PER_USER'));
-    $this->assertFalse(count($info) > 1, t('No more than one block defined.'));
+    // Check that unlinked users see link message.
+    $this->drupalLogin($this->unlinkedUser);
+    $this->drupalGet('<front>');
+    $this->assertText('Link to Yoti');
   }
 
   /**

--- a/yoti/tests/yoti.test
+++ b/yoti/tests/yoti.test
@@ -93,6 +93,14 @@ class YotiTest extends DrupalWebTestCase {
 
     // Configure module.
     $this->configureModule();
+
+    // Create a linked user.
+    $this->linkedUser = $this->drupalCreateUser();
+    db_insert(YotiHelper::YOTI_USER_TABLE_NAME)->fields([
+      'uid' => $this->linkedUser->uid,
+      'identifier' => 'some-remember-me-id',
+      'data' => serialize(array()),
+    ])->execute();
   }
 
   /**
@@ -131,7 +139,7 @@ class YotiTest extends DrupalWebTestCase {
     $this->drupalPost('admin/structure/block/manage/yoti/yoti_link/configure', $edit, t('Save block'));
 
     // Check that the block is present with the correct configuration.
-    $this->drupalGet('admin/structure/block');
+    $this->drupalGet('<front>');
     $this->assertText('Link to Yoti');
 
     // Test that tokens were rendered correctly.
@@ -153,6 +161,21 @@ class YotiTest extends DrupalWebTestCase {
       $attribute_values,
       'Check button markup is correct.'
     );
+
+    // Check that linked users see linked message.
+    $this->drupalLogin($this->linkedUser);
+
+    $this->drupalGet('<front>');
+    $this->assertText('Yoti Linked');
+  }
+
+  /**
+   * Test Yoti Block Info.
+   */
+  public function testBlockInfo() {
+    $info = module_invoke('yoti', 'block_info');
+    $this->assertEqual(DRUPAL_CACHE_PER_USER, $info['yoti_link']['cache'], t('Cache is set to DRUPAL_CACHE_PER_USER'));
+    $this->assertFalse(count($info) > 1, t('No more than one block defined.'));
   }
 
   /**

--- a/yoti/yoti.install
+++ b/yoti/yoti.install
@@ -96,32 +96,68 @@ function yoti_requirements($phase) {
 }
 
 /**
- * Implements hook_install().
+ * Implements hook_schema().
  */
-function yoti_install() {
-  $table_name = YotiHelper::YOTI_USER_TABLE_NAME;
-  db_query("CREATE TABLE IF NOT EXISTS `{$table_name}` (
-    `id` INT(10) UNSIGNED AUTO_INCREMENT,
-    `uid` int(10) UNSIGNED NOT NULL,
-    `identifier` VARCHAR(255) NOT NULL,
-    `data` TEXT NULL,
-    PRIMARY KEY `id` (`id`),
-    UNIQUE KEY `uid` (`uid`)
-  )")->execute();
+function yoti_schema() {
+  return array(
+    YotiHelper::YOTI_USER_TABLE_NAME => array(
+      'description' => 'Stores Yoti user data.',
+      'fields' => array(
+        'id' => array(
+          'description' => 'Unique identifier',
+          'type' => 'serial',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+        ),
+        'uid' => array(
+          'description' => 'Drupal user ID',
+          'type' => 'int',
+          'not null' => TRUE,
+          'unsigned' => TRUE,
+        ),
+        'identifier' => array(
+          'description' => 'Identifier',
+          'type' => 'varchar',
+          'length' => 255,
+          'not null' => TRUE,
+        ),
+        'data' => array(
+          'description' => 'Yoti user data',
+          'type' => 'text',
+        ),
+      ),
+      'primary key' => array(
+        'id',
+      ),
+      'unique keys' => array(
+        'uid' => array(
+          'uid',
+        ),
+      ),
+      // For documentation purposes only; foreign keys are not created in the
+      // database.
+      'foreign keys' => array(
+        'data_user' => array(
+          'table' => 'users',
+          'columns' => array(
+            'uid' => 'uid',
+          ),
+        ),
+      ),
+    ),
+  );
 }
 
 /**
  * Implements hook_uninstall().
  */
 function yoti_uninstall() {
-  $table_name = YotiHelper::YOTI_USER_TABLE_NAME;
   $yotiConfigArr = array_keys(YotiHelper::getConfig());
   foreach ($yotiConfigArr as $configKey) {
     if (!empty($configKey)) {
       variable_del($configKey);
     }
   }
-  db_query("DROP TABLE IF EXISTS `{$table_name}`")->execute();
 }
 
 /**

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -253,14 +253,11 @@ function yoti_user_view($account, $view_mode, $langcode) {
 
   foreach ($map as $param => $label) {
     $value = isset($dbProfile[$param]) ? $dbProfile[$param] : '';
-    if ($param === Profile::ATTR_SELFIE) {
+    if ($param === Profile::ATTR_SELFIE && !empty($dbProfile['selfie_filename'])) {
       // Make it backward compatible by checking the old files directory.
-      $oldSelfieFullPath = YotiHelper::uploadDir() . "/{$dbProfile['selfie_filename']}";
-      $selfieFullPath = YotiHelper::secureUploadDir() . "/{$dbProfile['selfie_filename']}";
-      if (
-          $dbProfile['selfie_filename']
-          && (file_exists($selfieFullPath) || file_exists($oldSelfieFullPath))
-      ) {
+      $oldSelfieFullPath = YotiHelper::uploadDir() . '/' . $dbProfile['selfie_filename'];
+      $selfieFullPath = YotiHelper::secureUploadDir() . '/' . $dbProfile['selfie_filename'];
+      if (is_file($selfieFullPath) || is_file($oldSelfieFullPath)) {
         $params = ['field' => 'selfie'];
         if ($isAdmin) {
           $params['user_id'] = $account->uid;

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -71,6 +71,7 @@ function yoti_block_info() {
   $blocks = [];
   $blocks['yoti_link'] = [
     'info' => t('Yoti Button'),
+    'cache' => DRUPAL_CACHE_PER_USER,
   ];
 
   return $blocks;

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -11,6 +11,24 @@ use Yoti\Entity\Profile;
 require_once __DIR__ . '/YotiHelper.php';
 
 /**
+ * Implements hook_theme().
+ */
+function yoti_theme($existing, $type, $theme, $path) {
+  return array(
+    'yoti_button' => array(
+      'variables' => array(
+        'app_id' => NULL,
+        'scenario_id' => NULL,
+        'is_linked' => FALSE,
+        'button_text' => NULL,
+      ),
+      'path' => $path . '/templates',
+      'template' => 'yoti-button',
+    ),
+  );
+}
+
+/**
  * Display these fields.
  *
  * @return array
@@ -71,7 +89,7 @@ function yoti_block_info() {
   $blocks = [];
   $blocks['yoti_link'] = [
     'info' => t('Yoti Button'),
-    'cache' => DRUPAL_CACHE_PER_USER,
+    'cache' => DRUPAL_NO_CACHE,
   ];
 
   return $blocks;
@@ -85,17 +103,64 @@ function yoti_block_view($delta = '') {
 
   $block = [];
 
-  // Add sdk url.
-  drupal_add_js(YotiHelper::YOTI_SDK_JAVASCRIPT_LIBRARY);
-  // Add Yoti css file.
-  drupal_add_css(drupal_get_path('module', 'yoti') . '/css/yoti.css', ['group' => CSS_DEFAULT, 'every_page' => TRUE]);
-
   // No config? no button.
   $config = YotiHelper::getConfig();
   if (!$config) {
     return $block;
   }
 
+  switch ($delta) {
+    case 'yoti_link':
+      if (empty($user->uid)) {
+        $button_text = YotiHelper::YOTI_LINK_BUTTON_DEFAULT_TEXT;
+        $is_linked = FALSE;
+      }
+      else {
+        $button_text = 'Link to Yoti';
+        $is_linked = !empty(YotiHelper::getYotiUserProfile($user->uid));
+      }
+
+      $block['content'] = array(
+        '#theme' => 'yoti_button',
+        '#is_linked' => $is_linked,
+        '#button_text' => check_plain($button_text),
+        '#app_id' => check_plain($config['yoti_app_id']),
+        '#scenario_id' => check_plain($config['yoti_scenario_id']),
+        '#attached' => array(
+          'css' => array(
+            array(
+              'data' => drupal_get_path('module', 'yoti') . '/css/yoti.css',
+              'group' => CSS_DEFAULT,
+              'every_page' => TRUE,
+            ),
+          ),
+          'js' => array(
+            array(
+              'type' => 'inline',
+              'data' => yoti_get_inline_script(),
+              'scope' => 'footer',
+            ),
+            array(
+              'type' => 'external',
+              'data' => YotiHelper::YOTI_SDK_JAVASCRIPT_LIBRARY,
+              'scope' => 'header',
+            ),
+          ),
+        ),
+      );
+      break;
+  }
+
+  return $block;
+}
+
+/**
+ * Returns the inline button JavaScript.
+ *
+ * @return string
+ *   Inline button JavaScript,
+ */
+function yoti_get_inline_script() {
   $script = [];
 
   // If connect url starts with 'https://staging' then we are in staging mode.
@@ -110,31 +175,8 @@ function yoti_block_view($delta = '') {
 
   // Add init()
   $script[] = '_ybg.init();';
-  $linkButton = '<span
-            data-yoti-application-id="' . $config['yoti_app_id'] . '"
-            data-yoti-type="inline"
-            data-yoti-scenario-id="' . $config['yoti_scenario_id'] . '"
-            data-size="small">
-            %s
-        </span>
-        <script>' . implode("\r\n", $script) . '</script>';
 
-  if (!$user->uid) {
-    $button = sprintf($linkButton, YotiHelper::YOTI_LINK_BUTTON_DEFAULT_TEXT);
-  }
-  else {
-    $dbProfile = YotiHelper::getYotiUserProfile($user->uid);
-    if ($dbProfile) {
-      $button = '<strong>Yoti</strong> Linked';
-    }
-    else {
-      $button = sprintf($linkButton, 'Link to Yoti');
-    }
-  }
-
-  $block['content'] = '<div class="yoti-connect">' . $button . '</div>';
-
-  return $block;
+  return implode("\r\n", $script);
 }
 
 /**


### PR DESCRIPTION
- Disabled block cache _(as per `user_block_info()` in core)_ - we can consider introducing per user caching at a later date, which would also involve custom invalidation
  _(This has been solved in  D8 with cache tags)_
- Using database abstraction for database schema and select query so that SimpleTest table prefix can be used when running tests
- Moved button markup into a custom theme and attached JS/CSS to the block
  _(Attaching JS/CSS will help if/when we implement caching)_
- Fix to prevent notice when `selfie_filename` is not available
- Test coverage for block when user is both linked and unlinked