### PR TITLE
SDK-958: Requirements

### DIFF
--- a/docker/install-drupal.sh
+++ b/docker/install-drupal.sh
@@ -11,10 +11,10 @@ docker-compose up -d $TARGET
 sleep 10
 
 # Install Drupal
-docker-compose exec $TARGET drush site:install -y
+docker-compose exec $TARGET sudo -u www-data -E drush site:install -y
 
 # Set private file path
 docker-compose exec $TARGET drush vset file_private_path /var/www/private
 
 # Enable Yoti module
-docker-compose exec $TARGET drush en yoti -y
+docker-compose exec $TARGET sudo -u www-data -E drush en yoti -y

--- a/docker/install-drupal.sh
+++ b/docker/install-drupal.sh
@@ -13,5 +13,8 @@ sleep 10
 # Install Drupal
 docker-compose exec $TARGET drush site:install -y
 
+# Set private file path
+docker-compose exec $TARGET drush vset file_private_path /var/www/private
+
 # Enable Yoti module
 docker-compose exec $TARGET drush en yoti -y

--- a/docker/settings.php
+++ b/docker/settings.php
@@ -15,6 +15,3 @@ $databases['default']['default'] = [
   'prefix' => '',
   'username' => getenv('MYSQL_USER'),
 ];
-
-// Configure private file path.
-$conf['file_private_path'] = '/var/www/private';

--- a/yoti/tests/yoti.test
+++ b/yoti/tests/yoti.test
@@ -59,10 +59,7 @@ class YotiTest extends DrupalWebTestCase {
     'yoti_success_url' => 'test_yoti_success_url',
     'yoti_fail_url' => 'test_yoti_fail_url',
     'yoti_user_email' => 'test_yoti_user_email',
-    'yoti_pem' => array(
-      'name' => 'test.pem',
-      'contents' => 'pem_contents',
-    ),
+    'yoti_pem' => 'pem_contents',
   );
 
   /**
@@ -105,6 +102,10 @@ class YotiTest extends DrupalWebTestCase {
     foreach ($this->yotiConfig as $key => $value) {
       variable_set($key, $value);
     }
+
+    // Create a test pem file.
+    $pem_file = file_save_data($this->yotiConfig['yoti_pem'], 'private://yoti_test.pem', FILE_EXISTS_REPLACE);
+    variable_set('yoti_pem', $pem_file->fid);
   }
 
   /**

--- a/yoti/tests/yoti.test
+++ b/yoti/tests/yoti.test
@@ -59,6 +59,10 @@ class YotiTest extends DrupalWebTestCase {
     'yoti_success_url' => 'test_yoti_success_url',
     'yoti_fail_url' => 'test_yoti_fail_url',
     'yoti_user_email' => 'test_yoti_user_email',
+    'yoti_pem' => array(
+      'name' => 'test.pem',
+      'contents' => 'pem_contents',
+    ),
   );
 
   /**
@@ -81,18 +85,35 @@ class YotiTest extends DrupalWebTestCase {
   public function setUp() {
     parent::setUp($this->modules);
 
-    // Save test config.
-    foreach ($this->yotiConfig as $key => $value) {
-      variable_set($key, $value);
-    }
-
     // Create admin user.
     $this->adminUser = $this->drupalCreateUser(array(
       'access administration pages',
       'administer yoti',
       'administer blocks',
       'administer modules',
+      'administer site configuration',
     ));
+
+    // Configure module.
+    $this->configureModule();
+  }
+
+  /**
+   * Configure module.
+   */
+  private function configureModule() {
+    foreach ($this->yotiConfig as $key => $value) {
+      variable_set($key, $value);
+    }
+  }
+
+  /**
+   * Delete configuration.
+   */
+  private function deleteModuleConfiguration() {
+    foreach (array_keys($this->yotiConfig) as $key) {
+      variable_del($key);
+    }
   }
 
   /**
@@ -131,6 +152,25 @@ class YotiTest extends DrupalWebTestCase {
       $attribute_values,
       'Check button markup is correct.'
     );
+  }
+
+  /**
+   * Test Yoti Requirements.
+   */
+  public function testRequirements() {
+    $this->drupalLogin($this->adminUser);
+    $this->drupalGet('admin/reports/status');
+    $this->assertNoText('Yoti Configuration');
+
+    $this->deleteModuleConfiguration();
+    $this->drupalGet('admin/reports/status');
+    $this->assertText('Yoti Configuration');
+    $this->assertText('Not Configured');
+    $this->assertText('Please configure the following:');
+    $this->assertText('Application ID (yoti_app_id)');
+    $this->assertText('Scenario ID (yoti_scenario_id)');
+    $this->assertText('SDK ID (yoti_sdk_id)');
+    $this->assertText('PEM File (yoti_pem)');
   }
 
 }

--- a/yoti/yoti.install
+++ b/yoti/yoti.install
@@ -15,45 +15,80 @@ function yoti_requirements($phase) {
   $requirements = [];
   $t = get_t();
 
-  if ($phase == 'install') {
-    if (!function_exists('curl_init')) {
-      $requirements['curl']['severity'] = REQUIREMENT_ERROR;
-      $requirements['curl']['description'] = $t('Yoti could not be installed. The cURL library is not installed. Please check the <a href="@url">PHP cURL documentation</a> for information on how to correct this.', ['@url' => 'http://www.php.net/manual/en/curl.setup.php']);
-    }
+  switch ($phase) {
+    case 'install':
 
-    if (!function_exists('json_decode')) {
-      $requirements['json']['severity'] = REQUIREMENT_ERROR;
-      $requirements['json']['description'] = $t('Yoti could not be installed. The JSON library is not installed. Yoti PHP SDK needs the JSON PHP extension.');
-    }
+      if (!function_exists('curl_init')) {
+        $requirements['curl']['severity'] = REQUIREMENT_ERROR;
+        $requirements['curl']['description'] = $t('Yoti could not be installed. The cURL library is not installed. Please check the <a href="@url">PHP cURL documentation</a> for information on how to correct this.', ['@url' => 'http://www.php.net/manual/en/curl.setup.php']);
+      }
 
-    if (version_compare(phpversion(), '5.4.0', '<')) {
-      $requirements['php_version']['title'] = $t('PHP version');
-      $requirements['php_version']['value'] = check_plain(phpversion());
-      $requirements['php_version']['severity'] = REQUIREMENT_ERROR;
-      $requirements['php_version']['description'] = $t('Yoti could not be installed. Yoti PHP SDK requires PHP 5.4 or higher.');
-    }
+      if (!function_exists('json_decode')) {
+        $requirements['json']['severity'] = REQUIREMENT_ERROR;
+        $requirements['json']['description'] = $t('Yoti could not be installed. The JSON library is not installed. Yoti PHP SDK needs the JSON PHP extension.');
+      }
 
-    // Check Drupal private file path is set.
-    $privateDir = isset($conf['file_private_path']) ? $conf['file_private_path'] : NULL;
-    $yotiUploadDir = $privateDir . '/yoti';
-    if (!$privateDir) {
-      $requirements['php_version']['title'] = $t('Secure folder');
-      $requirements['php_version']['value'] = $privateDir;
-      $requirements['php_version']['severity'] = REQUIREMENT_ERROR;
-      $requirements['php_version']['description'] = $t('Yoti requires that you have the file_private_path setting enabled for your website. This should be set in Configuration -> File system -> Private file system path');
-    }
-    elseif (!is_dir($yotiUploadDir)) {
-      // Create Yoti upload dir if it doesn't exists.
-      drupal_mkdir($yotiUploadDir);
-    }
+      if (version_compare(phpversion(), '5.4.0', '<')) {
+        $requirements['php_version']['title'] = $t('PHP version');
+        $requirements['php_version']['value'] = check_plain(phpversion());
+        $requirements['php_version']['severity'] = REQUIREMENT_ERROR;
+        $requirements['php_version']['description'] = $t('Yoti could not be installed. Yoti PHP SDK requires PHP 5.4 or higher.');
+      }
 
-    // Check Yoti files upload folder exists and is writable.
-    if ($privateDir && !is_writable($yotiUploadDir)) {
-      $requirements['php_version']['title'] = $t('Yoti secure folder');
-      $requirements['php_version']['value'] = $yotiUploadDir;
-      $requirements['php_version']['severity'] = REQUIREMENT_ERROR;
-      $requirements['php_version']['description'] = $t('Yoti could not be installed. The following folder must exist and be writable by the server: ' . $yotiUploadDir);
-    }
+      // Check Drupal private file path is set.
+      $privateDir = isset($conf['file_private_path']) ? $conf['file_private_path'] : NULL;
+      $yotiUploadDir = $privateDir . '/yoti';
+      if (!$privateDir) {
+        $requirements['php_version']['title'] = $t('Secure folder');
+        $requirements['php_version']['value'] = $privateDir;
+        $requirements['php_version']['severity'] = REQUIREMENT_ERROR;
+        $requirements['php_version']['description'] = $t('Yoti requires that you have the file_private_path setting enabled for your website. This should be set in Configuration -> File system -> Private file system path');
+      }
+      elseif (!is_dir($yotiUploadDir)) {
+        // Create Yoti upload dir if it doesn't exists.
+        drupal_mkdir($yotiUploadDir);
+      }
+
+      // Check Yoti files upload folder exists and is writable.
+      if ($privateDir && !is_writable($yotiUploadDir)) {
+        $requirements['php_version']['title'] = $t('Yoti secure folder');
+        $requirements['php_version']['value'] = $yotiUploadDir;
+        $requirements['php_version']['severity'] = REQUIREMENT_ERROR;
+        $requirements['php_version']['description'] = $t('Yoti could not be installed. The following folder must exist and be writable by the server: ' . $yotiUploadDir);
+      }
+
+      break;
+
+    case 'runtime':
+      // Check that the module is configured properly.
+      $required_config = array(
+        'yoti_app_id' => 'Application ID',
+        'yoti_scenario_id' => 'Scenario ID',
+        'yoti_sdk_id' => 'SDK ID',
+        'yoti_pem' => 'PEM File',
+      );
+
+      $items = [];
+      foreach ($required_config as $variable => $label) {
+        if (!variable_get($variable)) {
+          $items[] = $t(':label (:variable)', array(
+            ':label' => $label,
+            ':variable' => $variable,
+          ));
+        }
+      }
+
+      if (count($items) > 0) {
+        $requirements['yoti_config']['title'] = $t('Yoti Configuration');
+        $requirements['yoti_config']['value'] = 'Not Configured';
+        $requirements['yoti_config']['severity'] = REQUIREMENT_ERROR;
+        $item_list = array(
+          'items' => $items,
+        );
+        $requirements['yoti_config']['description'] = $t('Please configure the following: !items', array(
+          '!items' => theme('item_list', $item_list),
+        ));
+      }
 
   }
 

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -232,44 +232,6 @@ function yoti_permission() {
 }
 
 /**
- * This function will initialize the App.
- *
- * @return true
- *   if initialization was OK. false otherwise.
- */
-function yoti_initialize() {
-  // Check that PHP version is 5.4 or higher.
-  if (version_compare(phpversion(), '5.4.0', '<')) {
-    drupal_set_message(t('Yoti not configured properly.'), 'error');
-    watchdog(
-        'yoti',
-        'Yoti PHP SDK requires PHP 5.4 or higher. Your PHP version is @version',
-        ['@version' => phpversion()],
-        WATCHDOG_ERROR
-    );
-    return FALSE;
-  }
-
-  // Check that the module is configured properly.
-  $app_id = variable_get('yoti_app_id', 0);
-  $app_secret = variable_get('yoti_sdk_id', 0);
-
-  if (!$app_id || !$app_secret) {
-    drupal_set_message(t('Yoti not configured properly.'), 'error');
-    watchdog(
-        'yoti',
-        'Could not initialize Yoti app. Define APP ID and PEM file on module settings.',
-        [],
-        WATCHDOG_ERROR
-    );
-    return FALSE;
-  }
-
-  // If we have not returned FALSE, SDK is found and module has been configured.
-  return TRUE;
-}
-
-/**
  * Implements hook_ENTITY_TYPE_view() for user entities.
  */
 function yoti_user_view($account, $view_mode, $langcode) {


### PR DESCRIPTION
- Moved "Yoti Configuration" check into `hook_requirements()`
- Added test for requirements
- Setting private file path on install using `drush vset` _(database variable)_ so that _SimpleTest_ can override during test run _(`settings.php` take priority over database variables)_
- Creating test pem file to prevent warnings when running tests
- Installing module as `www-data` so that private folder ownership is correct