### PR TITLE
SDK-959: Unlink confirmation

### DIFF
--- a/yoti/tests/yoti.test
+++ b/yoti/tests/yoti.test
@@ -211,6 +211,41 @@ class YotiTest extends DrupalWebTestCase {
   }
 
   /**
+   * Test Unlink Form.
+   */
+  public function testUnlinkForm() {
+    $this->drupalLogin($this->linkedUser);
+    $this->drupalGet('user');
+
+    $this->assertElementByXpath(
+      "//div[contains(@class,:wrapper_class)]//a[@href=:href][@id=:id]",
+      array(
+        ':wrapper_class' => 'yoti-connect',
+        ':href' => '/yoti/unlink',
+        ':id' => 'yoti-unlink-button',
+        ':class' => 'button',
+      ),
+      'Check unlink Yoti Account link'
+    );
+
+    $this->clickLink('Unlink Yoti Account');
+    $this->assertElementByXpath(
+      "//h1[contains(text(),:text)]",
+      array(
+        ':text' => 'Unlink Yoti Account',
+      ),
+      'Check Unlink Yoti Account title'
+    );
+    $this->assertText('Are you sure you want to unlink your account from Yoti?');
+    $this->drupalPost('yoti/unlink', array(), t('Yes'));
+    $this->assertUrl('/');
+
+    // Check account was unlinked.
+    $this->drupalGet('user');
+    $this->assertNoText('Unlink Yoti Account');
+  }
+
+  /**
    * Test Yoti Requirements.
    */
   public function testRequirements() {

--- a/yoti/tests/yoti.test
+++ b/yoti/tests/yoti.test
@@ -211,6 +211,29 @@ class YotiTest extends DrupalWebTestCase {
   }
 
   /**
+   * Test link menu item for linked users.
+   */
+  public function testLinkForLinkedUsers() {
+    $this->drupalLogin($this->linkedUser);
+    $this->drupalGet('yoti/link');
+    $this->assertResponse(403);
+    $this->assertText('Access denied');
+  }
+
+  /**
+   * Test link menu item for unlinked users.
+   */
+  public function testLinkForUnlinkedUsers() {
+    $this->drupalLogin($this->unlinkedUser);
+
+    $this->drupalGet('yoti/link', array('query' => array('token' => '')));
+    $this->assertText('Could not get Yoti token.');
+
+    $this->drupalGet('yoti/link', array('query' => array('token' => 'some-invalid-token')));
+    $this->assertText('Yoti could not successfully connect to your account.');
+  }
+
+  /**
    * Test Unlink Form.
    */
   public function testUnlinkForm() {

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -211,7 +211,8 @@ function yoti_menu() {
   $items['yoti/unlink'] = [
     'href' => 'yoti/unlink',
     'title' => 'Unlink Yoti',
-    'page callback' => 'yoti_unlink',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => ['yoti_unlink'],
     'access callback' => 'has_yoti_login',
     'type' => MENU_CALLBACK,
     'file' => 'yoti.pages.inc',
@@ -323,13 +324,19 @@ function yoti_user_view($account, $view_mode, $langcode) {
   }
 
   if ($current->uid === $account->uid) {
-    $account->content['summary']['yoti_unlink'] = [
-      '#type' => 'item',
-      '#markup' => '<div class="yoti-connect">' .
-      '<a  class="button" onclick="return confirm(\'' . $promptMessage . '\')" id="yoti-unlink-button" href="' .
-      url('/yoti/unlink') . '">' .
-      t('Unlink Yoti Account') .
-      '</a></div>',
-    ];
+    $account->content['summary']['yoti_unlink'] = array(
+      '#theme' => 'link',
+      '#text' => t('Unlink Yoti Account'),
+      '#path' => 'yoti/unlink',
+      '#prefix' => '<div class="yoti-connect">',
+      '#suffix' => '</div>',
+      '#options' => array(
+        'attributes' => array(
+          'class' => array('button'),
+          'id' => 'yoti-unlink-button',
+        ),
+        'html' => FALSE,
+      ),
+    );
   }
 }

--- a/yoti/yoti.pages.inc
+++ b/yoti/yoti.pages.inc
@@ -8,7 +8,7 @@
 require_once __DIR__ . '/YotiHelper.php';
 
 /**
- * Authenticate Yoti user and link to current user account.
+ * Page callback to handle linking of Yoti user to current user.
  */
 function yoti_link() {
   // Resume as normal.

--- a/yoti/yoti.pages.inc
+++ b/yoti/yoti.pages.inc
@@ -8,19 +8,9 @@
 require_once __DIR__ . '/YotiHelper.php';
 
 /**
- * Authenticate Yoti user or unlink if user is already linked to Yoti user.
+ * Authenticate Yoti user and link to current user account.
  */
 function yoti_link() {
-  global $user;
-
-  // Check if user already has an account.
-  if ($user) {
-    $dbProfile = YotiHelper::getYotiUserProfile($user->uid);
-    if ($dbProfile) {
-      return yoti_unlink();
-    }
-  }
-
   // Resume as normal.
   $helper = new YotiHelper();
   if (!array_key_exists('token', $_GET)) {
@@ -34,9 +24,28 @@ function yoti_link() {
 }
 
 /**
- * Unlink drupal user from Yoti user.
+ * Form to confirm unlinking of Drupal user from Yoti user.
+ *
+ * @ingroup forms
+ * @see yoti_unlink_submit()
  */
 function yoti_unlink() {
+  return confirm_form(
+    array(),
+    'Unlink Yoti Account',
+    '<front>',
+    'Are you sure you want to unlink your account from Yoti?',
+    t('Yes'),
+    t('Cancel')
+  );
+}
+
+/**
+ * Form submission handler for yoti_unlink().
+ *
+ * @see yoti_unlink()
+ */
+function yoti_unlink_submit() {
   $helper = new YotiHelper();
   $helper->unlink();
   return drupal_goto('/');


### PR DESCRIPTION
- Using confirmation form when unlinking account instead of JavaScript popup
- Removed redundant code that unlinks account on link action.
  _Users with linked account cannot reach this page as `yoti/link` menu item has `no_yoti_login()` access callback. I've added some test coverage for link actions to demonstrate this_


