### PR TITLE
SDK-960: Unlink confirmation

### DIFF
--- a/yoti/src/Controller/YotiStartController.php
+++ b/yoti/src/Controller/YotiStartController.php
@@ -81,22 +81,7 @@ class YotiStartController extends ControllerBase {
   }
 
   /**
-   * Check if current account is linked.
-   *
-   * @param \Drupal\Core\Session\AccountInterface $account
-   *   Run access checks for this account.
-   *
-   * @return \Drupal\Core\Access\AccessResult
-   *   If account is linked isAllowed() will be TRUE, otherwise
-   *   isNeutral() will be TRUE.
-   */
-  public static function accessAccountIsLinked(AccountInterface $account) {
-    $db_profile = YotiUserModel::getYotiUserById($account->id());
-    return AccessResult::allowedIf(!empty($db_profile));
-  }
-
-  /**
-   * Check if current account is not linked.
+   * Check that current account is not linked.
    *
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Run access checks for this account.
@@ -105,7 +90,7 @@ class YotiStartController extends ControllerBase {
    *   If account is not linked isAllowed() will be TRUE, otherwise
    *   isNeutral() will be TRUE.
    */
-  public static function accessAccountNotLinked(AccountInterface $account) {
+  public static function accessLink(AccountInterface $account) {
     $db_profile = YotiUserModel::getYotiUserById($account->id());
     return AccessResult::allowedIf(empty($db_profile));
   }

--- a/yoti/src/Controller/YotiStartController.php
+++ b/yoti/src/Controller/YotiStartController.php
@@ -7,6 +7,8 @@ use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\yoti\YotiHelper;
 use Drupal\yoti\Models\YotiUserModel;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
 
 require_once __DIR__ . '/../../sdk/boot.php';
 
@@ -45,17 +47,6 @@ class YotiStartController extends ControllerBase {
   }
 
   /**
-   * Unlink user account from Yoti.
-   */
-  public function unlink() {
-    /** @var \Drupal\yoti\YotiHelper $helper */
-    $helper = \Drupal::service('yoti.helper');
-
-    $helper->unlink();
-    return $this->redirect('user.login');
-  }
-
-  /**
    * Send binary file from Yoti.
    */
   public function binFile($field) {
@@ -87,6 +78,34 @@ class YotiStartController extends ControllerBase {
     readfile($file);
     // Returning response here as required by Drupal controller action.
     return new TrustedRedirectResponse('yoti.bin-file');
+  }
+
+  /**
+   * Check if current account is linked.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Run access checks for this account.
+   *
+   * @return bool
+   *   TRUE or FALSE
+   */
+  public static function accessAccountIsLinked(AccountInterface $account) {
+    $db_profile = YotiUserModel::getYotiUserById($account->id());
+    return AccessResult::allowedIf(!empty($db_profile));
+  }
+
+  /**
+   * Check if current account is not linked.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Run access checks for this account.
+   *
+   * @return bool
+   *   TRUE or FALSE
+   */
+  public static function accessAccountNotLinked(AccountInterface $account) {
+    $db_profile = YotiUserModel::getYotiUserById($account->id());
+    return AccessResult::allowedIf(empty($db_profile));
   }
 
 }

--- a/yoti/src/Controller/YotiStartController.php
+++ b/yoti/src/Controller/YotiStartController.php
@@ -86,8 +86,9 @@ class YotiStartController extends ControllerBase {
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Run access checks for this account.
    *
-   * @return bool
-   *   TRUE or FALSE
+   * @return \Drupal\Core\Access\AccessResult
+   *   If account is linked isAllowed() will be TRUE, otherwise
+   *   isNeutral() will be TRUE.
    */
   public static function accessAccountIsLinked(AccountInterface $account) {
     $db_profile = YotiUserModel::getYotiUserById($account->id());
@@ -100,8 +101,9 @@ class YotiStartController extends ControllerBase {
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Run access checks for this account.
    *
-   * @return bool
-   *   TRUE or FALSE
+   * @return \Drupal\Core\Access\AccessResult
+   *   If account is not linked isAllowed() will be TRUE, otherwise
+   *   isNeutral() will be TRUE.
    */
   public static function accessAccountNotLinked(AccountInterface $account) {
     $db_profile = YotiUserModel::getYotiUserById($account->id());

--- a/yoti/src/Form/YotiUnlinkForm.php
+++ b/yoti/src/Form/YotiUnlinkForm.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\yoti\Form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Url;
+
+/**
+ * Class YotiUnlinkForm.
+ *
+ * @package Drupal\yoti\Form
+ */
+class YotiUnlinkForm extends ConfirmFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    \Drupal::service('yoti.helper')->unlink();
+    $form_state->setRedirect('user.page');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return "yoti_unlink_form";
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('user.page');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return t('Unlink Yoti Account');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    return t('Are you sure you want to unlink your account from Yoti?');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return $this
+      ->t('Yes');
+  }
+
+}

--- a/yoti/src/Form/YotiUnlinkForm.php
+++ b/yoti/src/Form/YotiUnlinkForm.php
@@ -5,6 +5,9 @@ namespace Drupal\yoti\Form;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Url;
+use Drupal\yoti\Models\YotiUserModel;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
 
 /**
  * Class YotiUnlinkForm.
@@ -12,6 +15,21 @@ use Drupal\Core\Url;
  * @package Drupal\yoti\Form
  */
 class YotiUnlinkForm extends ConfirmFormBase {
+
+  /**
+   * Check that the current account is linked.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Run access checks for this account.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   If account is linked isAllowed() will be TRUE, otherwise
+   *   isNeutral() will be TRUE.
+   */
+  public static function access(AccountInterface $account) {
+    $db_profile = YotiUserModel::getYotiUserById($account->id());
+    return AccessResult::allowedIf(!empty($db_profile));
+  }
 
   /**
    * {@inheritdoc}

--- a/yoti/src/YotiHelper.php
+++ b/yoti/src/YotiHelper.php
@@ -204,8 +204,6 @@ class YotiHelper {
     if ($currentUser->isAnonymous()) {
       // Register new user.
       if (!$drupalUid) {
-        $errMsg = NULL;
-
         // Attempt to connect by email.
         $drupalUid = $this->shouldLoginByEmail($activityDetails);
 

--- a/yoti/tests/src/Functional/YotiBlockTest.php
+++ b/yoti/tests/src/Functional/YotiBlockTest.php
@@ -2,14 +2,12 @@
 
 namespace Drupal\Tests\yoti\Functional;
 
-use Drupal\Tests\BrowserTestBase;
-
 /**
  * Tests the Yoti block.
  *
  * @group yoti
  */
-class YotiBlockTest extends BrowserTestBase {
+class YotiBlockTest extends YotiBrowserTestBase {
 
   /**
    * Modules to enable.
@@ -35,7 +33,7 @@ class YotiBlockTest extends BrowserTestBase {
    */
   public function testYotiBlock() {
     // Place the block.
-    $block = $this->drupalPlaceBlock('yoti_block');
+    $this->drupalPlaceBlock('yoti_block');
 
     // Load the homepage.
     $this->drupalGet('<front>');
@@ -47,8 +45,9 @@ class YotiBlockTest extends BrowserTestBase {
       '[data-yoti-scenario-id=\'test_scenario_id\']',
       '[data-size=\'small\']',
     ];
-    $this->assertSession()->elementExists('css', 'span' . implode('', $span_attributes));
-    $this->assertSession()->elementExists('css', 'script[src*=\'js/browser-loader.js\']');
+    $assert = $this->assertSession();
+    $assert->elementExists('css', 'span' . implode('', $span_attributes));
+    $assert->elementExists('css', 'script[src*=\'js/browser-loader.js\']');
   }
 
 }

--- a/yoti/tests/src/Functional/YotiBrowserTestBase.php
+++ b/yoti/tests/src/Functional/YotiBrowserTestBase.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\Tests\yoti\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\yoti\YotiHelper;
+
+/**
+ * BrowserTestBase for Yoti tests.
+ *
+ * @group yoti
+ */
+class YotiBrowserTestBase extends BrowserTestBase {
+
+  /**
+   * Linked User.
+   *
+   * @var \Drupal\user\Entity\User
+   */
+  protected $linkedUser;
+
+  /**
+   * Unlinked User.
+   *
+   * @var \Drupal\user\Entity\User
+   */
+  protected $unlinkedUser;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = ['yoti'];
+
+  /**
+   * Setup Tests.
+   */
+  public function setup() {
+    parent::setup();
+
+    $this->linkedUser = $this->drupalCreateUser([
+      'access content',
+    ]);
+    \Drupal::database()->insert(YotiHelper::YOTI_USER_TABLE_NAME)->fields([
+      'uid' => $this->linkedUser->id(),
+      'identifier' => 'some-remember-me-id',
+      'data' => serialize([]),
+    ])->execute();
+
+    $this->unlinkedUser = $this->drupalCreateUser([
+      'access content',
+    ]);
+  }
+
+}

--- a/yoti/tests/src/Functional/YotiLinkTest.php
+++ b/yoti/tests/src/Functional/YotiLinkTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\Tests\yoti\Functional;
+
+/**
+ * Tests the link route.
+ *
+ * @group yoti
+ */
+class YotiLinkTest extends YotiBrowserTestBase {
+
+  /**
+   * Test link menu item for linked users.
+   */
+  public function testLinkForLinkedUsers() {
+    $assert = $this->assertSession();
+
+    $this->drupalLogin($this->linkedUser);
+    $this->drupalGet('yoti/link');
+    $assert->statusCodeEquals(403);
+    $assert->pageTextContains('Access denied');
+  }
+
+  /**
+   * Test link menu item for unlinked users.
+   */
+  public function testLinkForUnlinkedUsers() {
+    $assert = $this->assertSession();
+
+    $this->drupalLogin($this->unlinkedUser);
+
+    $this->drupalGet('yoti/link', ['query' => ['token' => '']]);
+    $assert->pageTextContains('Could not get Yoti token.');
+
+    $this->drupalGet('yoti/link', ['query' => ['token' => 'some-invalid-token']]);
+    $assert->pageTextContains('Yoti could not successfully connect to your account.');
+  }
+
+}

--- a/yoti/tests/src/Functional/YotiPermissionTest.php
+++ b/yoti/tests/src/Functional/YotiPermissionTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\yoti\Functional;
 
-use Drupal\Tests\BrowserTestBase;
 use Drupal\user\RoleInterface;
 use Drupal\user\Entity\Role;
 
@@ -11,21 +10,7 @@ use Drupal\user\Entity\Role;
  *
  * @group yoti
  */
-class YotiPermissionTest extends BrowserTestBase {
-
-  /**
-   * Modules to enable.
-   *
-   * @var array
-   */
-  public static $modules = ['yoti'];
-
-  /**
-   * Test user.
-   *
-   * @var \Drupal\user\UserInterface
-   */
-  protected $testUser;
+class YotiPermissionTest extends YotiBrowserTestBase {
 
   /**
    * User's role ID.
@@ -37,22 +22,17 @@ class YotiPermissionTest extends BrowserTestBase {
   /**
    * Setup permission tests.
    */
-  protected function setUp() {
+  public function setUp() {
     parent::setUp();
 
-    // Create a test user.
-    $this->testUser = $this->drupalCreateUser([
-      'access content',
-    ]);
-
     // Get the new role ID.
-    $all_rids = $this->testUser
+    $all_rids = $this->unlinkedUser
       ->getRoles();
     unset($all_rids[array_search(RoleInterface::AUTHENTICATED_ID, $all_rids)]);
     $this->rid = reset($all_rids);
 
     // Log test user in before each test.
-    $this->drupalLogin($this->testUser);
+    $this->drupalLogin($this->unlinkedUser);
   }
 
   /**
@@ -65,10 +45,10 @@ class YotiPermissionTest extends BrowserTestBase {
 
     $this->drupalGet('admin/config/people/yoti');
 
-    $assertSession = $this->assertSession();
-    $assertSession->statusCodeEquals(200);
-    $assertSession->pageTextContains('YOTI DASHBOARD');
-    $assertSession->elementExists('css', '#yoti-admin-form');
+    $assert = $this->assertSession();
+    $assert->statusCodeEquals(200);
+    $assert->pageTextContains('YOTI DASHBOARD');
+    $assert->elementExists('css', '#yoti-admin-form');
   }
 
   /**
@@ -77,10 +57,10 @@ class YotiPermissionTest extends BrowserTestBase {
   public function testYotiPermissionNotGranted() {
     $this->drupalGet('admin/config/people/yoti');
 
-    $assertSession = $this->assertSession();
-    $assertSession->statusCodeEquals(403);
-    $assertSession->pageTextContains('ACCESS DENIED');
-    $assertSession->elementNotExists('css', '#yoti-admin-form');
+    $assert = $this->assertSession();
+    $assert->statusCodeEquals(403);
+    $assert->pageTextContains('ACCESS DENIED');
+    $assert->elementNotExists('css', '#yoti-admin-form');
   }
 
 }

--- a/yoti/tests/src/Functional/YotiUnlinkFormTest.php
+++ b/yoti/tests/src/Functional/YotiUnlinkFormTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\Tests\yoti\Functional;
+
+/**
+ * Tests the Yoti unlink form.
+ *
+ * @group yoti
+ */
+class YotiUnlinkFormTest extends YotiBrowserTestBase {
+
+  /**
+   * Test Unlink Form.
+   */
+  public function testUnlinkForm() {
+    $this->drupalLogin($this->linkedUser);
+    $this->drupalGet('user');
+
+    $assert = $this->assertSession();
+    $assert->elementTextContains(
+      'css',
+      "#yoti-unlink-button[href='/yoti/unlink']",
+      'Unlink Yoti account'
+    );
+
+    $this->clickLink('Unlink Yoti account');
+
+    $assert->elementTextContains(
+      'css',
+      'h1',
+      'Unlink Yoti Account'
+    );
+
+    $assert->pageTextContains('Are you sure you want to unlink your account from Yoti?');
+    $this->drupalPostForm('yoti/unlink', [], t('Yes'));
+    $assert->addressMatches('~^/user/~');
+
+    // Check account was unlinked.
+    $this->drupalGet('user');
+    $assert->pageTextNotContains('Unlink Yoti Account');
+  }
+
+}

--- a/yoti/tests/src/Functional/YotiUserLoginFormTest.php
+++ b/yoti/tests/src/Functional/YotiUserLoginFormTest.php
@@ -2,30 +2,18 @@
 
 namespace Drupal\Tests\yoti\Functional;
 
-use Drupal\Tests\BrowserTestBase;
-
 /**
  * Tests the Yoti user login form.
  *
  * @group yoti
  */
-class YotiUserLoginFormTest extends BrowserTestBase {
-
-  /**
-   * Modules to enable.
-   *
-   * @var array
-   */
-  public static $modules = ['yoti'];
+class YotiUserLoginFormTest extends YotiBrowserTestBase {
 
   /**
    * Authenticated users can view login form.
    */
   public function testAuthenticatedUser() {
-    $testUser = $this->drupalCreateUser([
-      'access content',
-    ]);
-    $this->drupalLogin($testUser);
+    $this->drupalLogin($this->unlinkedUser);
 
     $this->drupalGet('yoti/register');
 

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -68,7 +68,6 @@ function yoti_entity_extra_field_info() {
  */
 function yoti_user_view(array &$build, UserInterface $account) {
   $map = yoti_map_params();
-  $promptMessage = 'This will unlink your account from Yoti.';
 
   $user = \Drupal::currentUser();
   $isAdmin = in_array('administrator', $user->getRoles(), TRUE);
@@ -111,8 +110,6 @@ function yoti_user_view(array &$build, UserInterface $account) {
     ];
   }
 
-  $onClickEvent = "return confirm('{$promptMessage}')";
-
   // Build Yoti unlink button.
   $unlinkUrl = Url::fromRoute('yoti.unlink');
   $link_options = [
@@ -120,7 +117,6 @@ function yoti_user_view(array &$build, UserInterface $account) {
       'id' => [
         'yoti-unlink-button',
       ],
-      'onclick' => $onClickEvent,
     ],
   ];
   $unlinkUrl->setOptions($link_options);

--- a/yoti/yoti.routing.yml
+++ b/yoti/yoti.routing.yml
@@ -4,6 +4,7 @@ yoti.link:
     _controller: '\Drupal\yoti\Controller\YotiStartController::link'
   requirements:
     _permission: 'access content'
+    _custom_access: '\Drupal\yoti\Controller\YotiStartController::accessAccountNotLinked'
   options:
     no_cache: TRUE
 
@@ -20,10 +21,11 @@ yoti.register:
 yoti.unlink:
   path: '/yoti/unlink'
   defaults:
-    _controller: '\Drupal\yoti\Controller\YotiStartController::unlink'
-    _title: 'Unlink yoti'
+    _form: '\Drupal\yoti\Form\YotiUnlinkForm'
+    _title: 'Unlink Yoti'
   requirements:
-    _permission: 'access content'
+    _user_is_logged_in: 'TRUE'
+    _custom_access: '\Drupal\yoti\Controller\YotiStartController::accessAccountIsLinked'
   options:
     no_cache: TRUE
 

--- a/yoti/yoti.routing.yml
+++ b/yoti/yoti.routing.yml
@@ -4,7 +4,7 @@ yoti.link:
     _controller: '\Drupal\yoti\Controller\YotiStartController::link'
   requirements:
     _permission: 'access content'
-    _custom_access: '\Drupal\yoti\Controller\YotiStartController::accessAccountNotLinked'
+    _custom_access: '\Drupal\yoti\Controller\YotiStartController::accessLink'
   options:
     no_cache: TRUE
 
@@ -25,7 +25,7 @@ yoti.unlink:
     _title: 'Unlink Yoti'
   requirements:
     _user_is_logged_in: 'TRUE'
-    _custom_access: '\Drupal\yoti\Controller\YotiStartController::accessAccountIsLinked'
+    _custom_access: '\Drupal\yoti\Form\YotiUnlinkForm::access'
   options:
     no_cache: TRUE
 


### PR DESCRIPTION
- Using confirmation form when unlinking account
- Added custom access checks on link/unlink routes for linked and unlinked accounts
- Added test coverage for link and unlink routes
- Tidied up tests _(now extend `YotiBrowserTestBase` to reduce setup duplication)_