### PR TITLE
SDK-1065: Use 8.7 Drupal Docker image

### DIFF
--- a/checkout-sdk.sh
+++ b/checkout-sdk.sh
@@ -6,7 +6,6 @@
 NAME="yoti-for-drupal-8.x-1.x-edge.zip"
 SDK_TAG=$1
 DEFAULT_SDK_TAG="1.2.1"
-SDK_RELATIVE_PATH="sdk"
 
 if [ "$SDK_TAG" = "" ]; then
     SDK_TAG=$DEFAULT_SDK_TAG
@@ -24,8 +23,8 @@ if [ ! -d "./yoti" ]; then
     exit
 fi
 
-cp -R "$SDK_RELATIVE_PATH" "./yoti/sdk"
-zip -r "$NAME" "./yoti"
+rm -fr ./yoti/sdk
+cp -R sdk ./yoti/sdk
 
 rm -rf sdk
 echo "Fetched PHP SDK TAG $SDK_TAG."

--- a/docker/app.base.dockerfile
+++ b/docker/app.base.dockerfile
@@ -1,8 +1,5 @@
 # from https://www.drupal.org/requirements/php#drupalversions
-FROM php:7.2-apache AS drupal_8_base
-
-# Fix for Error: Package 'php-XXX' has no installation candidate
-RUN rm /etc/apt/preferences.d/no-debian-php
+FROM drupal:8.7-apache AS drupal_8_base
 
 COPY default.conf /etc/apache2/sites-available/000-default.conf
 COPY ./keys/server.crt /etc/apache2/ssl/server.crt
@@ -10,50 +7,12 @@ COPY ./keys/server.key /etc/apache2/ssl/server.key
 
 RUN a2enmod rewrite ssl
 
-# install the PHP extensions we need
-RUN set -ex \
-	&& buildDeps=' \
-		libjpeg62-turbo-dev \
-		libpng-dev \
-		libpq-dev \
-	' \
-	&& apt-get update && apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-configure gd \
-		--with-jpeg-dir=/usr \
-		--with-png-dir=/usr \
-	&& docker-php-ext-install -j "$(nproc)" gd mbstring opcache pdo pdo_mysql pdo_pgsql zip \
-	&& apt-get update \
-	&& apt-get install -y git zip unzip vim nano php7.0-gd \
-# PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/local/lib/php/extensions/no-debug-non-zts-20151012/gd.so' - libjpeg.so.62: cannot open shared object file: No such file or directory in Unknown on line 0
-# PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/local/lib/php/extensions/no-debug-non-zts-20151012/pdo_pgsql.so' - libpq.so.5: cannot open shared object file: No such file or directory in Unknown on line 0
-	&& apt-mark manual \
-		libjpeg62-turbo \
-		libpq5 \
-	&& apt-get purge -y --auto-remove $buildDeps
+# Install dependencies.
+RUN apt-get update \
+  && apt-get install -y git zip unzip vim nano mysql-client
 
-# set recommended PHP.ini settings
-# see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
-		echo 'opcache.memory_consumption=128'; \
-		echo 'opcache.interned_strings_buffer=8'; \
-		echo 'opcache.max_accelerated_files=4000'; \
-		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
-		echo 'opcache.enable_cli=1'; \
-	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
-
-# https://www.drupal.org/node/3060/release
 ENV DIRPATH /var/www/html
-ENV DRUPAL_VERSION 8.6.15
-ENV DRUPAL_MD5 85ae6b9f7309cc8564331fd77369dffd
-
 WORKDIR $DIRPATH
-
-RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
-	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \
-	&& tar -xz --strip-components=1 -f drupal.tar.gz \
-	&& rm drupal.tar.gz \
-	&& chown -R www-data:www-data sites modules themes
 
 # Install Composer
 RUN EXPECTED_SIGNATURE="$(curl https://composer.github.io/installer.sig)" \
@@ -74,9 +33,6 @@ RUN curl -L -o drush.phar https://github.com/drush-ops/drush-launcher/releases/d
     && chmod +x drush.phar \
     && mv drush.phar /usr/local/bin/drush \
     && composer require drush/drush:^9.0
-
-# Install MySQL Client
-RUN apt-get install -y mysql-client
 
 # Create writable public files directory
 RUN mkdir sites/default/files \

--- a/pack-plugin.sh
+++ b/pack-plugin.sh
@@ -1,48 +1,19 @@
 #!/bin/bash
 
-NAME="yoti-for-drupal-8.x-1.x-edge.zip"
 SDK_TAG=$1
-DEFAULT_SDK_TAG="1.2.1"
+
+NAME="yoti-for-drupal-8.x-1.x-edge.zip"
 SDK_RELATIVE_PATH="sdk"
 
-if [ "$SDK_TAG" = "" ]; then
-    SDK_TAG=$DEFAULT_SDK_TAG
-fi
-
-echo "Pulling PHP SDK TAG $SDK_TAG.zip ..."
-
-curl https://github.com/getyoti/yoti-php-sdk/archive/$SDK_TAG.zip -O -L
-unzip $SDK_TAG.zip -d sdk
-mv sdk/yoti-php-sdk-$SDK_TAG/src/* sdk
-rm -rf sdk/yoti-php-sdk-$SDK_TAG
-
-if [ ! -d "./yoti" ]; then
-    echo "ERROR: Must be in directory containing ./yoti folder"
-    exit
-fi
-
-if [ ! -d "$SDK_RELATIVE_PATH" ]; then
-    "ERROR: Could not find SDK in $SDK_RELATIVE_PATH"
-    exit
-fi
+./checkout-sdk.sh "$SDK_TAG"
 
 echo "Packing plugin ..."
-
-# move sdk symlink (used in symlink-plugin-to-site.sh)
-sym_exist=0
-if [ -L "./yoti/sdk" ]; then
-    mv "./yoti/sdk" "./__sdk-sym";
-    sym_exist=1
-fi
 
 cp -R "$SDK_RELATIVE_PATH" "./yoti/sdk"
 zip -r "$NAME" "./yoti"
 rm -rf "./yoti/sdk"
 
-# move symlink back
-if [ $sym_exist ]; then
-    mv "./__sdk-sym" "./yoti/sdk"
-fi
 rm -rf sdk
+
 echo "Plugin packed. File $NAME created."
 echo ""

--- a/yoti/tests/src/Unit/YotiHelperTest.php
+++ b/yoti/tests/src/Unit/YotiHelperTest.php
@@ -21,7 +21,6 @@ use Drupal\user\UserInterface;
 use Drupal\yoti\YotiConfigInterface;
 use Drupal\yoti\YotiHelper;
 use Drupal\yoti\YotiSdkInterface;
-use Egulias\EmailValidator\EmailValidatorInterface;
 use Psr\Log\LoggerInterface;
 use Yoti\YotiClient;
 use Yoti\Exception\ActivityDetailsException;
@@ -361,11 +360,19 @@ class YotiHelperTest extends YotiUnitTestBase {
   /**
    * Creates mock email validator.
    *
-   * @return \Egulias\EmailValidator\EmailValidatorInterface
+   * @return \Drupal\Component\Utility\EmailValidatorInterface
    *   Email validator.
    */
   private function createMockEmailValidator() {
-    $email_validator = $this->createMock(EmailValidatorInterface::class);
+    // Allow testing with Drupal 8.6.x and below.
+    // @see https://www.drupal.org/node/2997196
+    if (interface_exists('\Egulias\EmailValidator\EmailValidatorInterface')) {
+      $email_validator_class = '\Egulias\EmailValidator\EmailValidatorInterface';
+    }
+    else {
+      $email_validator_class = '\Drupal\Component\Utility\EmailValidatorInterface';
+    }
+    $email_validator = $this->createMock($email_validator_class);
     $email_validator
       ->method('isValid')
       ->willReturn(TRUE);


### PR DESCRIPTION
> Same as #46 but for `8.x-1.x`

### Changed
- Using Drupal 8.7 image from https://hub.docker.com/_/drupal/
- `./pack-plugin.sh` now calls `./checkout-sdk.sh` to remove duplication

### Fixed
- Added logic in test to mock email validator service using the available `EmailValidatorInterface` - caused by https://www.drupal.org/node/2997196