### PR TITLE
SDK-1045: Update block to display modal QR

### DIFF
--- a/yoti/js/browser-loader.js
+++ b/yoti/js/browser-loader.js
@@ -3,16 +3,11 @@
     var script = document.createElement('script');
     script.type='text/javascript';
     script.async='async';
-    script.src='https://sdk.yoti.com/clients/browser.2.2.0.js';
+    script.src='https://www.yoti.com/share/client/';
 
     // Initialise button once browser JS is loaded.
     script.addEventListener('load', function() {
-        // Collect inline _ybg config.
-        var config = window._ybg_config || {};
-        for (i in config) {
-            _ybg.config[i] = config[i];
-        }
-        _ybg.init();
+        window.Yoti.Share.init(yotiConfig);
     });
 
     document.head.appendChild(script);

--- a/yoti/src/Controller/YotiStartController.php
+++ b/yoti/src/Controller/YotiStartController.php
@@ -28,11 +28,6 @@ class YotiStartController extends ControllerBase {
     $helper = \Drupal::service('yoti.helper');
     $config = \Drupal::service('yoti.config');
 
-    // If no token is given check if we are in mock request mode.
-    if (!array_key_exists('token', $_GET)) {
-      return new TrustedRedirectResponse($helper::getLoginUrl());
-    }
-
     $result = $helper->link();
     if (!$result) {
       $failedURL = YotiHelper::getPathFullUrl($config->getFailUrl());

--- a/yoti/src/Form/YotiSettingsForm.php
+++ b/yoti/src/Form/YotiSettingsForm.php
@@ -75,6 +75,7 @@ class YotiSettingsForm extends ConfigFormBase {
       $this->t('Warning: User IDs provided by Yoti are unique to each Yoti Application. Using a different Yoti Application means you will receive a different Yoti User ID for all of your users.'),
     ];
 
+    // @deprecated `yoti_app_id` will be removed in next major release.
     $form['yoti_settings']['yoti_app_id'] = [
       '#type' => 'textfield',
       '#required' => TRUE,

--- a/yoti/src/Plugin/Block/YotiBlock.php
+++ b/yoti/src/Plugin/Block/YotiBlock.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\yoti\Plugin\Block;
 
-use Yoti\YotiClient;
 use Drupal\Core\Block\BlockBase;
 use Drupal\yoti\YotiHelper;
 use Drupal\yoti\Models\YotiUserModel;
@@ -40,18 +39,6 @@ class YotiBlock extends BlockBase {
       return [];
     }
 
-    $qr_url = NULL;
-    $service_url = NULL;
-
-    // If connect url starts with 'https://staging' then we are in staging mode.
-    $is_staging = strpos(YotiClient::CONNECT_BASE_URL, 'https://staging') === 0;
-    if ($is_staging) {
-      // Base url for connect.
-      $base_url = preg_replace('/^(.+)\/connect$/', '$1', YotiClient::CONNECT_BASE_URL);
-      $qr_url = sprintf('%s/qr/', $base_url);
-      $service_url = sprintf('%s/connect/', $base_url);
-    }
-
     // Set button text based on current user.
     $userId = $user->id();
     if (!$userId) {
@@ -65,13 +52,10 @@ class YotiBlock extends BlockBase {
 
     return [
       '#theme' => 'yoti_button',
-      '#app_id' => $config->getAppId(),
+      '#button_id' => 'yoti-button-' . $this->getPluginId(),
       '#scenario_id' => $config->getScenarioId(),
       '#button_text' => $button_text,
       '#is_linked' => $is_linked,
-      '#is_staging' => $is_staging,
-      '#qr_url' => $qr_url,
-      '#service_url' => $service_url,
       '#attached' => [
         'library' => [
           'yoti/yoti',

--- a/yoti/src/YotiConfig.php
+++ b/yoti/src/YotiConfig.php
@@ -75,6 +75,7 @@ class YotiConfig implements YotiConfigInterface {
       $name = $file->getFileUri();
       $contents = file_get_contents($this->fileSystem->realpath($name));
     }
+    // @deprecated `yoti_app_id` will be removed in next major release.
     $this->settings = [
       'yoti_app_id' => $settings->get('yoti_app_id'),
       'yoti_scenario_id' => $settings->get('yoti_scenario_id'),
@@ -94,13 +95,6 @@ class YotiConfig implements YotiConfigInterface {
    */
   public function getSettings() {
     return $this->settings;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getAppId() {
-    return $this->settings['yoti_app_id'];
   }
 
   /**

--- a/yoti/src/YotiConfig.php
+++ b/yoti/src/YotiConfig.php
@@ -75,7 +75,7 @@ class YotiConfig implements YotiConfigInterface {
       $name = $file->getFileUri();
       $contents = file_get_contents($this->fileSystem->realpath($name));
     }
-    // @deprecated `yoti_app_id` will be removed in next major release.
+
     $this->settings = [
       'yoti_app_id' => $settings->get('yoti_app_id'),
       'yoti_scenario_id' => $settings->get('yoti_scenario_id'),

--- a/yoti/src/YotiConfigInterface.php
+++ b/yoti/src/YotiConfigInterface.php
@@ -18,14 +18,6 @@ interface YotiConfigInterface {
   public function getSettings();
 
   /**
-   * Yoti App ID.
-   *
-   * @return string
-   *   App ID.
-   */
-  public function getAppId();
-
-  /**
    * Yoti Scenario ID.
    *
    * @return string

--- a/yoti/src/YotiHelper.php
+++ b/yoti/src/YotiHelper.php
@@ -12,6 +12,7 @@ use Yoti\ActivityDetails;
 use Yoti\Entity\Profile;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Yoti\YotiClient;
 
 require_once __DIR__ . '/../sdk/boot.php';
 
@@ -746,13 +747,14 @@ class YotiHelper {
   /**
    * Get Yoti Dashboard app URL.
    *
-   * @deprecated use `yoti.sdk` service instead.
+   * @deprecated `yoti_app_id` will be removed in next major release.
    *
    * @return null|string
    *   Yoti App URL.
    */
   public static function getLoginUrl() {
-    return \Drupal::service('yoti.sdk')->getLoginUrl();
+    $settings = \Drupal::service('yoti.config')->getSettings();
+    return YotiClient::getLoginUrl($settings['yoti_app_id']);
   }
 
   /**

--- a/yoti/src/YotiHelper.php
+++ b/yoti/src/YotiHelper.php
@@ -747,7 +747,7 @@ class YotiHelper {
   /**
    * Get Yoti Dashboard app URL.
    *
-   * @deprecated `yoti_app_id` will be removed in next major release.
+   * @deprecated - `yoti_app_id` will be removed in next major release. Login will be through a Modal QR.
    *
    * @return null|string
    *   Yoti App URL.

--- a/yoti/templates/yoti-button.html.twig
+++ b/yoti/templates/yoti-button.html.twig
@@ -4,36 +4,26 @@
  * Yoti Button.
  *
  * Available variables:
- * - app_id: Yoti App ID
+ * - button_id: Yoti Button ID
  * - scenario_id: Yoti Scenario ID
  * - button_text: Button Text
  * - is_linked: Flag for linked accounts
- * - is_staging: Flag for staging
- * - qr_url: QR URL
- * - service_url: Service URL
  */
 #}
 <div class="yoti-connect">
 {% if is_linked %}
     <strong>Yoti</strong> Linked
 {% else %}
-    <span
-        data-yoti-application-id="{{app_id}}"
-        data-yoti-type="inline"
-        data-yoti-scenario-id="{{scenario_id}}"
-        data-size="small">
-        {{button_text}}
-    </span>
-    {% if is_staging %}
+    <div id="{{button_id}}"></div>
     <script>
-        var _ybg_config = {};
-        {% if qr_url %}
-        _ybg_config.qr = "{{qr_url}}";
-        {% endif %}
-        {% if service_url %}
-        _ybg_config.service = "{{service_url}}";
-        {% endif %}
+    var yotiConfig = yotiConfig || { elements: [] };
+    yotiConfig.elements.push({
+        "domId": "{{button_id}}",
+        "scenarioId": "{{scenario_id}}",
+        "button": {
+            "label": "{{button_text}}"
+        }
+    });
     </script>
-    {% endif %}
 {% endif %}
 </div>

--- a/yoti/tests/src/Functional/YotiBlockTest.php
+++ b/yoti/tests/src/Functional/YotiBlockTest.php
@@ -23,7 +23,6 @@ class YotiBlockTest extends YotiBrowserTestBase {
     parent::setup();
 
     $this->config('yoti.settings')
-      ->set('yoti_app_id', 'test_app_id')
       ->set('yoti_scenario_id', 'test_scenario_id')
       ->save();
   }
@@ -39,15 +38,12 @@ class YotiBlockTest extends YotiBrowserTestBase {
     $this->drupalGet('<front>');
 
     // Check the block has been placed.
-    $span_attributes = [
-      '[data-yoti-application-id=\'test_app_id\']',
-      '[data-yoti-type=\'inline\']',
-      '[data-yoti-scenario-id=\'test_scenario_id\']',
-      '[data-size=\'small\']',
-    ];
     $assert = $this->assertSession();
-    $assert->elementExists('css', 'span' . implode('', $span_attributes));
+    $assert->elementExists('css', "div[id='yoti-button-yoti_block']");
     $assert->elementExists('css', 'script[src*=\'js/browser-loader.js\']');
+    $assert->responseMatches('~"domId":.*?"yoti-button-yoti_block"~');
+    $assert->responseMatches('~"scenarioId":.*?"test_scenario_id"~');
+    $assert->responseMatches('~"label":.*?"Use Yoti"~');
   }
 
 }

--- a/yoti/tests/src/Unit/YotiConfigTest.php
+++ b/yoti/tests/src/Unit/YotiConfigTest.php
@@ -94,13 +94,6 @@ class YotiConfigTest extends YotiUnitTestBase {
   }
 
   /**
-   * @covers ::getAppId
-   */
-  public function testGetAppId() {
-    $this->assertEquals($this->config->getAppId(), $this->settings['yoti_app_id']);
-  }
-
-  /**
    * @covers ::getScenarioId
    */
   public function testGetScenarioId() {

--- a/yoti/tests/src/Unit/YotiHelperTest.php
+++ b/yoti/tests/src/Unit/YotiHelperTest.php
@@ -95,7 +95,7 @@ class YotiHelperTest extends YotiUnitTestBase {
       $cacheTagsInvalidator,
       $this->createMock(LoggerChannelFactoryInterface::class),
       $sdk,
-      $this->createMock(YotiConfigInterface::class)
+      $this->createMockConfig()
     );
 
     // Attempt link with no token.
@@ -140,7 +140,7 @@ class YotiHelperTest extends YotiUnitTestBase {
       $this->createMock(CacheTagsInvalidatorInterface::class),
       $this->createMockLoggerFactory($logger),
       $this->createMockSdk(),
-      $this->createMock(YotiConfigInterface::class)
+      $this->createMockConfig()
     );
 
     $_GET['token'] = 'test_token';
@@ -164,7 +164,7 @@ class YotiHelperTest extends YotiUnitTestBase {
       $cacheTagsInvalidator,
       $this->createMock(LoggerChannelFactoryInterface::class),
       $this->createMock(YotiSdkInterface::class),
-      $this->createMock(YotiConfigInterface::class)
+      $this->createMockConfig()
     );
 
     $helper->unlink();
@@ -179,7 +179,7 @@ class YotiHelperTest extends YotiUnitTestBase {
       $this->createMock(CacheTagsInvalidatorInterface::class),
       $this->createMock(LoggerChannelFactoryInterface::class),
       $this->createMock(YotiSdkInterface::class),
-      $this->createMock(YotiConfigInterface::class)
+      $this->createMockConfig()
     );
 
     $this->assertFileExists($this->selfieFilePath);
@@ -427,6 +427,7 @@ class YotiHelperTest extends YotiUnitTestBase {
     $container->set('language_manager', $this->createMockLanguageManager());
     $container->set('file_system', $this->createMockFileSystem());
     $container->set('yoti.sdk', $this->createMockSdk());
+    $container->set('yoti.config', $this->createMockConfig());
     \Drupal::setContainer($container);
   }
 
@@ -508,11 +509,26 @@ class YotiHelperTest extends YotiUnitTestBase {
     $sdk
       ->method('getClient')
       ->willReturn($client);
-    $sdk
-      ->method('getLoginUrl')
-      ->willReturn('https://www.yoti.com/connect/test_app_id');
 
     return $sdk;
+  }
+
+  /**
+   * Creates mock config service.
+   *
+   * @return \Drupal\yoti\YotiConfigInterface
+   *   Yoti Config service.
+   */
+  private function createMockConfig() {
+    $config = $this->createMock(YotiConfigInterface::class);
+    $config
+      ->method('getSettings')
+      ->willReturn([
+        'yoti_app_id' => 'test_app_id',
+        'yoti_scenario_id' => 'test_scenario_id',
+        'yoti_sdk_id' => 'test_sdk_id',
+      ]);
+    return $config;
   }
 
   /**

--- a/yoti/tests/src/Unit/YotiSdkTest.php
+++ b/yoti/tests/src/Unit/YotiSdkTest.php
@@ -30,9 +30,6 @@ class YotiSdkTest extends YotiUnitTestBase {
     $config
       ->method('getSdkId')
       ->willReturn('test_sdk_id');
-    $config
-      ->method('getAppId')
-      ->willReturn('test_app_id');
 
     openssl_pkey_export(openssl_pkey_new(), $pem_contents);
     $config
@@ -48,14 +45,6 @@ class YotiSdkTest extends YotiUnitTestBase {
   public function testGetClient() {
     $sdk = new YotiSdk($this->config);
     $this->assertInstanceOf(YotiClient::class, $sdk->getClient());
-  }
-
-  /**
-   * @covers ::getLoginUrl
-   */
-  public function testGetLoginUrl() {
-    $sdk = new YotiSdk($this->config);
-    $this->assertEquals('https://www.yoti.com/connect/test_app_id', $sdk->getLoginUrl());
   }
 
 }

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -28,13 +28,10 @@ function yoti_theme($existing, $type, $theme, $path) {
   return [
     'yoti_button' => [
       'variables' => [
-        'app_id' => NULL,
+        'button_id' => NULL,
         'scenario_id' => NULL,
         'button_text' => NULL,
-        'is_staging' => NULL,
         'is_linked' => NULL,
-        'qr_url' => NULL,
-        'service_url' => NULL,
       ],
     ],
   ];


### PR DESCRIPTION
### Changed
- Yoti button now shows modal QR

### Removed
- App ID changes that have not yet been released
- Fallback behaviour that redirects users to connect page when token isn't provided to link controller. _(This relies on App ID that will be removed in next major release)_

### Deprecated
- App ID (added comments indicating removal in next major release)