### PR TITLE
SDK-1066: User profile

### DIFF
--- a/yoti/src/Controller/YotiStartController.php
+++ b/yoti/src/Controller/YotiStartController.php
@@ -95,7 +95,7 @@ class YotiStartController extends ControllerBase {
   /**
    * Check access to bin files.
    *
-   * @param AccountInterface $account
+   * @param \Drupal\Core\Session\AccountInterface $account
    *   Run access checks for this account.
    *
    * @return \Drupal\Core\Access\AccessResult

--- a/yoti/src/Controller/YotiStartController.php
+++ b/yoti/src/Controller/YotiStartController.php
@@ -7,7 +7,7 @@ use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\yoti\YotiHelper;
 use Drupal\yoti\Models\YotiUserModel;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\user\Entity\User;
@@ -57,12 +57,12 @@ class YotiStartController extends ControllerBase {
     $targetUser = self::getTargetUser($current);
 
     if (!($targetUser instanceof UserInterface)) {
-      return $this->notFoundResponse();
+      throw new NotFoundHttpException();
     }
 
     $dbProfile = YotiUserModel::getYotiUserById($targetUser->id());
     if (!$dbProfile) {
-      return $this->notFoundResponse();
+      throw new NotFoundHttpException();
     }
 
     // Unserialize Yoti user data.
@@ -70,13 +70,13 @@ class YotiStartController extends ControllerBase {
 
     $field = ($field === 'selfie') ? 'selfie_filename' : $field;
     if (!is_array($userProfileArr) || !array_key_exists($field, $userProfileArr)) {
-      return $this->notFoundResponse();
+      throw new NotFoundHttpException();
     }
 
     // Get user selfie file path.
     $file = YotiHelper::uploadDir() . "/{$userProfileArr[$field]}";
     if (!is_file($file)) {
-      return $this->notFoundResponse();
+      throw new NotFoundHttpException();
     }
 
     // Returning response here as required by Drupal controller action.
@@ -128,16 +128,6 @@ class YotiStartController extends ControllerBase {
   private static function getTargetUser(AccountInterface $account) {
     $userId = (!empty($_GET['user_id'])) ? (int) $_GET['user_id'] : $account->id();
     return User::load($userId);
-  }
-
-  /**
-   * Return a 404 response.
-   *
-   * @return \Symfony\Component\HttpFoundation\Response
-   *   The 404 response.
-   */
-  private function notFoundResponse() {
-    return new Response(NULL, 404, []);
   }
 
 }

--- a/yoti/src/Controller/YotiStartController.php
+++ b/yoti/src/Controller/YotiStartController.php
@@ -6,9 +6,11 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\yoti\YotiHelper;
 use Drupal\yoti\Models\YotiUserModel;
-use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\user\Entity\User;
 
 require_once __DIR__ . '/../../sdk/boot.php';
 
@@ -51,11 +53,10 @@ class YotiStartController extends ControllerBase {
    */
   public function binFile($field) {
     $current = \Drupal::currentUser();
-    $isAdmin = in_array('administrator', $current->getRoles(), TRUE);
-    $userId = (!empty($_GET['user_id']) && $isAdmin) ? (int) $_GET['user_id'] : $current->id();
+    $userId = (!empty($_GET['user_id'])) ? (int) $_GET['user_id'] : $current->id();
     $dbProfile = YotiUserModel::getYotiUserById($userId);
     if (!$dbProfile) {
-      return;
+      return $this->notFoundResponse();
     }
 
     // Unserialize Yoti user data.
@@ -63,21 +64,17 @@ class YotiStartController extends ControllerBase {
 
     $field = ($field === 'selfie') ? 'selfie_filename' : $field;
     if (!is_array($userProfileArr) || !array_key_exists($field, $userProfileArr)) {
-      return;
+      return $this->notFoundResponse();
     }
 
     // Get user selfie file path.
     $file = YotiHelper::uploadDir() . "/{$userProfileArr[$field]}";
-    if (!file_exists($file)) {
-      return;
+    if (!is_file($file)) {
+      return $this->notFoundResponse();
     }
 
-    $type = 'image/png';
-    header('Content-Type:' . $type);
-    header('Content-Length: ' . filesize($file));
-    readfile($file);
     // Returning response here as required by Drupal controller action.
-    return new TrustedRedirectResponse('yoti.bin-file');
+    return new BinaryFileResponse($file, 200);
   }
 
   /**
@@ -93,6 +90,31 @@ class YotiStartController extends ControllerBase {
   public static function accessLink(AccountInterface $account) {
     $db_profile = YotiUserModel::getYotiUserById($account->id());
     return AccessResult::allowedIf(empty($db_profile));
+  }
+
+  /**
+   * Check access to bin files.
+   *
+   * @param AccountInterface $account
+   *   Run access checks for this account.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   If account can view target user isAllowed() will be TRUE.
+   */
+  public static function accessBinFile(AccountInterface $account) {
+    $userId = (!empty($_GET['user_id'])) ? (int) $_GET['user_id'] : $account->id();
+    $targetUser = User::load($userId);
+    return AccessResult::allowedIf($targetUser->access('view', $account));
+  }
+
+  /**
+   * Return a 404 response.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   The 404 response.
+   */
+  private function notFoundResponse() {
+    return new Response(NULL, 404, []);
   }
 
 }

--- a/yoti/tests/src/Functional/YotiProfileTest.php
+++ b/yoti/tests/src/Functional/YotiProfileTest.php
@@ -71,7 +71,8 @@ class YotiProfileTest extends YotiBrowserTestBase {
     unset($profile_data[YotiHelper::ATTR_SELFIE_FILE_NAME]);
     unset($profile_data[Profile::ATTR_SELFIE]);
 
-    foreach ($profile_data as $label) {
+    foreach ($profile_data as $key => $label) {
+      $assert->elementExists('css', '#yoti-profile-' . $key);
       $assert->responseContains($label . ' value');
     }
 
@@ -83,8 +84,20 @@ class YotiProfileTest extends YotiBrowserTestBase {
     );
 
     // Check selfie image is present.
-    $assert->elementExists('css', "img[src*='/yoti/bin-file/selfie'][width='100']");
-    $this->drupalGet('yoti/bin-file/selfie');
+    $selfie_selector = "img[src*='/yoti/bin-file/selfie'][width='100']";
+    $assert->elementExists('css', $selfie_selector);
+
+    // Visit selfie using img src attribute.
+    $selfie_url = $this
+      ->getSession()
+      ->getPage()
+      ->find('css', $selfie_selector)
+      ->getAttribute('src');
+
+    $path = parse_url($selfie_url, PHP_URL_PATH);
+    parse_str(parse_url($selfie_url, PHP_URL_QUERY), $query_params);
+
+    $this->drupalGet(trim($path, '/'), ['query' => $query_params]);
     $assert->responseContains('test_selfie_contents');
   }
 

--- a/yoti/tests/src/Functional/YotiProfileTest.php
+++ b/yoti/tests/src/Functional/YotiProfileTest.php
@@ -33,7 +33,6 @@ class YotiProfileTest extends YotiBrowserTestBase {
    * Test viewing profile as user with permission.
    */
   public function testProfileLinkedAsUserWithPermission() {
-    // Create unlinked user.
     $userWithUserProfilePermission = $this->drupalCreateUser([
       'access user profiles',
     ]);
@@ -49,7 +48,6 @@ class YotiProfileTest extends YotiBrowserTestBase {
    * Test viewing profile as user without permission.
    */
   public function testProfileLinkedAsUserWithoutPermission() {
-    // Create unlinked user.
     $userWithoutUserProfilePermission = $this->drupalCreateUser();
     $this->drupalLogin($userWithoutUserProfilePermission);
     $this->drupalGet('user/' . $this->linkedUser->id());

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -72,7 +72,6 @@ function yoti_user_view(array &$build, UserInterface $account, EntityViewDisplay
   $map = yoti_map_params();
 
   $user = \Drupal::currentUser();
-  $isAdmin = in_array('administrator', $user->getRoles(), TRUE);
 
   $dbProfile = YotiUserModel::getYotiUserById($account->id());
   if (!$dbProfile) {
@@ -97,16 +96,11 @@ function yoti_user_view(array &$build, UserInterface $account, EntityViewDisplay
       }
       $selfieFullPath = YotiHelper::uploadDir() . "/{$selfieFileName}";
       if (!empty($selfieFileName) && is_file($selfieFullPath)) {
-        $params = [
-          'field' => 'selfie',
-        ];
-        if ($isAdmin) {
-          $params['user_id'] = $account->id();
-        }
         $field_content = [
           '#theme' => 'image',
           '#uri' => Url::fromRoute('yoti.bin-file', [
             'field' => 'selfie',
+            'user_id' => $account->id(),
           ])->toString(),
           '#width' => 100,
         ];

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -11,6 +11,7 @@ use Drupal\yoti\YotiHelper;
 use Yoti\Entity\Profile;
 use Drupal\yoti\Models\YotiUserModel;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Component\Utility\Html;
 
 require_once __DIR__ . '/sdk/boot.php';
 
@@ -72,7 +73,8 @@ function yoti_user_view(array &$build, UserInterface $account, EntityViewDisplay
 
   $user = \Drupal::currentUser();
   $isAdmin = in_array('administrator', $user->getRoles(), TRUE);
-  $dbProfile = YotiUserModel::getYotiUserById($user->id());
+
+  $dbProfile = YotiUserModel::getYotiUserById($account->id());
   if (!$dbProfile) {
     return;
   }
@@ -85,7 +87,8 @@ function yoti_user_view(array &$build, UserInterface $account, EntityViewDisplay
       continue;
     }
 
-    $value = isset($userProfileArr[$field]) ? $userProfileArr[$field] : '';
+    $field_content = [];
+
     if ($field === Profile::ATTR_SELFIE) {
       // Yoti user selfie file name.
       $selfieFileName = NULL;
@@ -94,25 +97,35 @@ function yoti_user_view(array &$build, UserInterface $account, EntityViewDisplay
       }
       $selfieFullPath = YotiHelper::uploadDir() . "/{$selfieFileName}";
       if (!empty($selfieFileName) && is_file($selfieFullPath)) {
-        $params = ['field' => 'selfie'];
+        $params = [
+          'field' => 'selfie',
+        ];
         if ($isAdmin) {
-          $params['user_id'] = $account->uid;
+          $params['user_id'] = $account->id();
         }
-        $selfieUrl = Url::fromRoute('yoti.bin-file', $params)->toString();
-        $value = '<img src="' . $selfieUrl . '" width="100" />';
+        $field_content = [
+          '#theme' => 'image',
+          '#uri' => Url::fromRoute('yoti.bin-file', [
+            'field' => 'selfie',
+          ])->toString(),
+          '#width' => 100,
+        ];
       }
-      else {
-        $value = '';
-      }
+    }
+    elseif (!empty($userProfileArr[$field])) {
+      $field_content['#plain_text'] = $userProfileArr[$field];
     }
 
-    if (!$value) {
-      $value = '<i>(empty)</i>';
+    if (empty($field_content)) {
+      $field_content['#markup'] = '<i>(empty)</i>';
     }
+
+    $field_content['#prefix'] = '<h4 class="label">' . Html::escape($label) . '</h4> ';
 
     $build[$field] = [
       '#type' => 'item',
-      '#markup' => '<h4 class="label">' . $label . '</h4> ' . $value,
+      '#id' => 'yoti-profile-' . $field,
+      'content' => $field_content,
     ];
   }
 

--- a/yoti/yoti.routing.yml
+++ b/yoti/yoti.routing.yml
@@ -34,7 +34,7 @@ yoti.bin-file:
   defaults:
     _controller: '\Drupal\yoti\Controller\YotiStartController::binFile'
   requirements:
-    _permission: 'access content'
+    _custom_access: '\Drupal\yoti\Controller\YotiStartController::accessBinFile'
     _csrf_token: 'TRUE'
   options:
     no_cache: TRUE

--- a/yoti/yoti.routing.yml
+++ b/yoti/yoti.routing.yml
@@ -35,6 +35,7 @@ yoti.bin-file:
     _controller: '\Drupal\yoti\Controller\YotiStartController::binFile'
   requirements:
     _permission: 'access content'
+    _csrf_token: 'TRUE'
   options:
     no_cache: TRUE
 


### PR DESCRIPTION
### Fixed
- Now displays corresponding user attributes on user profile pages instead of current user - This means attributes will be now viewable to anyone that have access to view user profiles.
   _Note: Please ensure you have reviewed which roles have `access user profiles` permission_
- Selfie image URL now has token

### Added
- User profile fields now have ID in format `yoti-profile-<field_key>`

### Changed
- Using `#prefix` to add label so that it can be optionally removed in theme - the resulting markup should be unchanged (non-breaking)