### PR TITLE
SDK-1066: User profile

### DIFF
--- a/yoti/Readme.md
+++ b/yoti/Readme.md
@@ -114,19 +114,8 @@ which allows Yoti accounts to link to email addresses.
 
 ## Customising User Profiles
 
-By default, all shared attributes are displayed on user profile pages. This
-can be customised using `hook_ENTITY_TYPE_view_alter()`.
-
-### Example
-
-```php
-/**
- * Implements hook_ENTITY_TYPE_view_alter().
- */
-function yoti_user_view_alter(array &$build) {
-  unset($build['full_name']);
-}
-```
+By default, all shared attributes are displayed on user profile pages.
+This can be customised at `/admin/config/people/accounts/display`.
 
 You can also control who can view user profiles using permissions
 at `/admin/people/permissions`.

--- a/yoti/src/Controller/YotiStartController.php
+++ b/yoti/src/Controller/YotiStartController.php
@@ -6,9 +6,12 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\yoti\YotiHelper;
 use Drupal\yoti\Models\YotiUserModel;
-use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
 
 require_once __DIR__ . '/../../sdk/boot.php';
 
@@ -51,11 +54,15 @@ class YotiStartController extends ControllerBase {
    */
   public function binFile($field) {
     $current = \Drupal::currentUser();
-    $isAdmin = in_array('administrator', $current->getRoles(), TRUE);
-    $userId = (!empty($_GET['user_id']) && $isAdmin) ? (int) $_GET['user_id'] : $current->id();
-    $dbProfile = YotiUserModel::getYotiUserById($userId);
+    $targetUser = self::getTargetUser($current);
+
+    if (!($targetUser instanceof UserInterface)) {
+      return $this->notFoundResponse();
+    }
+
+    $dbProfile = YotiUserModel::getYotiUserById($targetUser->id());
     if (!$dbProfile) {
-      return;
+      return $this->notFoundResponse();
     }
 
     // Unserialize Yoti user data.
@@ -63,21 +70,17 @@ class YotiStartController extends ControllerBase {
 
     $field = ($field === 'selfie') ? 'selfie_filename' : $field;
     if (!is_array($userProfileArr) || !array_key_exists($field, $userProfileArr)) {
-      return;
+      return $this->notFoundResponse();
     }
 
     // Get user selfie file path.
     $file = YotiHelper::uploadDir() . "/{$userProfileArr[$field]}";
-    if (!file_exists($file)) {
-      return;
+    if (!is_file($file)) {
+      return $this->notFoundResponse();
     }
 
-    $type = 'image/png';
-    header('Content-Type:' . $type);
-    header('Content-Length: ' . filesize($file));
-    readfile($file);
     // Returning response here as required by Drupal controller action.
-    return new TrustedRedirectResponse('yoti.bin-file');
+    return new BinaryFileResponse($file, 200);
   }
 
   /**
@@ -93,6 +96,48 @@ class YotiStartController extends ControllerBase {
   public static function accessLink(AccountInterface $account) {
     $db_profile = YotiUserModel::getYotiUserById($account->id());
     return AccessResult::allowedIf(empty($db_profile));
+  }
+
+  /**
+   * Check access to bin files.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Run access checks for this account.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   If account can view target user isAllowed() will be TRUE.
+   */
+  public static function accessBinFile(AccountInterface $account) {
+    if ($targetUser = self::getTargetUser($account)) {
+      return AccessResult::allowedIf($targetUser->access('view', $account));
+    }
+    return AccessResult::neutral();
+  }
+
+  /**
+   * Get the target user for this request defined by user_id GET parameter.
+   *
+   * Provided $account user will be returned by default.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Return this account when user_id is not specified as GET parameter.
+   *
+   * @return \Drupal\user\UserInterface|null
+   *   The target user.
+   */
+  private static function getTargetUser(AccountInterface $account) {
+    $userId = (!empty($_GET['user_id'])) ? (int) $_GET['user_id'] : $account->id();
+    return User::load($userId);
+  }
+
+  /**
+   * Return a 404 response.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   The 404 response.
+   */
+  private function notFoundResponse() {
+    return new Response(NULL, 404, []);
   }
 
 }

--- a/yoti/src/Controller/YotiStartController.php
+++ b/yoti/src/Controller/YotiStartController.php
@@ -7,7 +7,7 @@ use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\yoti\YotiHelper;
 use Drupal\yoti\Models\YotiUserModel;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\user\Entity\User;
@@ -57,12 +57,12 @@ class YotiStartController extends ControllerBase {
     $targetUser = self::getTargetUser($current);
 
     if (!($targetUser instanceof UserInterface)) {
-      return $this->notFoundResponse();
+      throw new NotFoundHttpException();
     }
 
     $dbProfile = YotiUserModel::getYotiUserById($targetUser->id());
     if (!$dbProfile) {
-      return $this->notFoundResponse();
+      throw new NotFoundHttpException();
     }
 
     // Unserialize Yoti user data.
@@ -70,13 +70,13 @@ class YotiStartController extends ControllerBase {
 
     $field = ($field === 'selfie') ? 'selfie_filename' : $field;
     if (!is_array($userProfileArr) || !array_key_exists($field, $userProfileArr)) {
-      return $this->notFoundResponse();
+      throw new NotFoundHttpException();
     }
 
     // Get user selfie file path.
     $file = YotiHelper::uploadDir() . "/{$userProfileArr[$field]}";
     if (!is_file($file)) {
-      return $this->notFoundResponse();
+      throw new NotFoundHttpException();
     }
 
     // Returning response here as required by Drupal controller action.
@@ -128,16 +128,6 @@ class YotiStartController extends ControllerBase {
   private static function getTargetUser(AccountInterface $account) {
     $userId = (!empty($_GET['user_id'])) ? (int) $_GET['user_id'] : $account->id();
     return User::load($userId);
-  }
-
-  /**
-   * Return a 404 response.
-   *
-   * @return \Symfony\Component\HttpFoundation\Response
-   *   The 404 response.
-   */
-  private function notFoundResponse() {
-    return new Response(NULL, 404, []);
   }
 
 }

--- a/yoti/tests/fixtures/config/core.entity_view_display.user.user.default.yml
+++ b/yoti/tests/fixtures/config/core.entity_view_display.user.user.default.yml
@@ -1,0 +1,80 @@
+langcode: en
+status: true
+id: user.user.default
+targetEntityType: user
+bundle: user
+mode: default
+content:
+  age_verified:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  date_of_birth:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  email_address:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  family_name:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  full_name:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  gender:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  given_names:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  member_for:
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  nationality:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  phone_number:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  postal_address:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  selfie:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  user_picture:
+    type: image
+    weight: 0
+    region: content
+    settings: {}
+    third_party_settings: {  }
+    label: hidden
+  yoti_unlink:
+    weight: 15
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/yoti/tests/src/Functional/YotiBrowserTestBase.php
+++ b/yoti/tests/src/Functional/YotiBrowserTestBase.php
@@ -27,6 +27,13 @@ class YotiBrowserTestBase extends BrowserTestBase {
   protected $unlinkedUser;
 
   /**
+   * Selfie file path.
+   *
+   * @var string
+   */
+  protected $selfieFilePath;
+
+  /**
    * Modules to enable.
    *
    * @var array
@@ -39,18 +46,56 @@ class YotiBrowserTestBase extends BrowserTestBase {
   public function setup() {
     parent::setup();
 
-    $this->linkedUser = $this->drupalCreateUser([
-      'access content',
-    ]);
-    \Drupal::database()->insert(YotiHelper::YOTI_USER_TABLE_NAME)->fields([
-      'uid' => $this->linkedUser->id(),
-      'identifier' => 'some-remember-me-id',
-      'data' => serialize([]),
-    ])->execute();
+    // Create linked user.
+    $this->createLinkedUser();
 
+    // Create unlinked user.
     $this->unlinkedUser = $this->drupalCreateUser([
       'access content',
     ]);
+  }
+
+  /**
+   * Create a linked Drupal User.
+   */
+  private function createLinkedUser() {
+    // Create linked user.
+    $this->linkedUser = $this->drupalCreateUser([
+      'access content',
+    ]);
+
+    // Generate test user data from known attributes.
+    foreach (yoti_map_params() as $field => $label) {
+      $user_data[$field] = $label . ' value';
+    }
+
+    // Create test selfie file.
+    mkdir(YotiHelper::uploadDir(), 0777, TRUE);
+    $this->selfieFilePath = YotiHelper::uploadDir() . DIRECTORY_SEPARATOR . 'test_selfie.jpg';
+    file_put_contents($this->selfieFilePath, 'test_selfie_contents');
+    $user_data[YotiHelper::ATTR_SELFIE_FILE_NAME] = basename($this->selfieFilePath);
+
+    \Drupal::database()->insert(YotiHelper::YOTI_USER_TABLE_NAME)->fields([
+      'uid' => $this->linkedUser->id(),
+      'identifier' => 'some-remember-me-id',
+      'data' => serialize($user_data),
+    ])->execute();
+
+  }
+
+  /**
+   * Teardown Tests.
+   */
+  public function teardown() {
+    // Cleanup selfie.
+    if (is_file($this->selfieFilePath)) {
+      unlink($this->selfieFilePath);
+    }
+
+    // Cleanup private directory.
+    rmdir(YotiHelper::uploadDir());
+
+    parent::teardown();
   }
 
 }

--- a/yoti/tests/src/Functional/YotiProfileTest.php
+++ b/yoti/tests/src/Functional/YotiProfileTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Drupal\Tests\yoti\Functional;
+
+use Drupal\yoti\YotiHelper;
+use Yoti\ActivityDetails;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tests the user profile.
+ *
+ * @group yoti
+ */
+class YotiProfileTest extends YotiBrowserTestBase {
+
+  /**
+   * Test profile for linked users.
+   */
+  public function testProfileLinked() {
+    $this->drupalLogin($this->linkedUser);
+    $this->drupalGet('user');
+    $this->assertProfileFields(yoti_map_params());
+
+    // Check unlink button is present.
+    $this->assertSession()->elementTextContains(
+      'css',
+      "#yoti-unlink-button[href='/yoti/unlink']",
+      'Unlink Yoti account'
+    );
+  }
+
+  /**
+   * Test viewing profile as user with permission.
+   */
+  public function testProfileLinkedAsUserWithPermission() {
+    $userWithUserProfilePermission = $this->drupalCreateUser([
+      'access user profiles',
+    ]);
+    $this->drupalLogin($userWithUserProfilePermission);
+    $this->drupalGet('user/' . $this->linkedUser->id());
+    $this->assertProfileFields(yoti_map_params());
+
+    // Check unlink button is not present.
+    $this->assertSession()->responseNotContains('/yoti/unlink');
+  }
+
+  /**
+   * Test viewing profile as user without permission.
+   */
+  public function testProfileLinkedAsUserWithoutPermission() {
+    $userWithoutUserProfilePermission = $this->drupalCreateUser();
+    $this->drupalLogin($userWithoutUserProfilePermission);
+    $this->drupalGet('user/' . $this->linkedUser->id());
+    $this->assertSession()->statusCodeEquals(403);
+  }
+
+  /**
+   * Test profile with customised display.
+   */
+  public function testProfileCustomiseDisplay() {
+    $disable_fields = [
+      ActivityDetails::ATTR_FULL_NAME,
+      ActivityDetails::ATTR_GIVEN_NAMES,
+    ];
+
+    // Import config and hide user fields.
+    $this->importUserDisplayConfig();
+    $this->hideUserDisplayFields($disable_fields);
+
+    $this->drupalLogin($this->linkedUser);
+    $this->drupalGet('user');
+
+    // Create array of display and disabled fields.
+    $profile_data = yoti_map_params();
+    foreach ($disable_fields as $disable_field) {
+      unset($profile_data[$disable_field]);
+      $disabled_data[$disable_field] = yoti_map_params()[$disable_field];
+    }
+
+    $this->assertProfileFields($profile_data);
+    $this->assertNotProfileFields($disabled_data);
+  }
+
+  /**
+   * Test profile for unlinked users.
+   */
+  public function testProfileUnlinked() {
+    $this->drupalLogin($this->unlinkedUser);
+    $this->drupalGet('user');
+    $this->assertNotProfileFields(yoti_map_params());
+  }
+
+  /**
+   * Assert that the provided profile fields are present on profile.
+   *
+   * @param array $profile_data
+   *   Array of profile data to check.
+   */
+  private function assertProfileFields(array $profile_data) {
+    $assert = $this->assertSession();
+
+    // Check profile data without selfie.
+    unset($profile_data[YotiHelper::ATTR_SELFIE_FILE_NAME]);
+    unset($profile_data[ActivityDetails::ATTR_SELFIE]);
+
+    foreach ($profile_data as $key => $label) {
+      $assert->elementExists('css', '#yoti-profile-' . $key);
+      $assert->responseContains($label . ' value');
+    }
+
+    // Check selfie image is present.
+    $selfie_selector = "img[src*='/yoti/bin-file/selfie'][width='100']";
+    $assert->elementExists('css', $selfie_selector);
+
+    // Visit selfie using img src attribute.
+    $selfie_src_attr = $this
+      ->getSession()
+      ->getPage()
+      ->find('css', $selfie_selector)
+      ->getAttribute('src');
+    $selfie_url = htmlspecialchars_decode($selfie_src_attr);
+
+    $path = parse_url($selfie_url, PHP_URL_PATH);
+    parse_str(parse_url($selfie_url, PHP_URL_QUERY), $query_params);
+
+    $this->drupalGet(trim($path, '/'), ['query' => $query_params]);
+    $assert->responseContains('test_selfie_contents');
+
+    // Go back to previous page.
+    $this->getSession()->back();
+  }
+
+  /**
+   * Assert that the provided profile fields are not present on profile.
+   *
+   * @param array $profile_data
+   *   Array of profile data to check.
+   */
+  private function assertNotProfileFields(array $profile_data) {
+    foreach ($profile_data as $label) {
+      $this->assertSession()->responseNotContains($label);
+    }
+  }
+
+  /**
+   * Get the user display configuration.
+   *
+   * @return \Drupal\Core\Config\Config
+   *   Editable configuration object.
+   */
+  private function getUserDisplayConfig() {
+    return \Drupal::service('config.factory')
+      ->getEditable('core.entity_view_display.user.user.default');
+  }
+
+  /**
+   * Import the default user display configuration.
+   */
+  private function importUserDisplayConfig() {
+    $config = $this->getUserDisplayConfig();
+
+    $yaml = file_get_contents(__DIR__ . '/../../fixtures/config/core.entity_view_display.user.user.default.yml');
+
+    $config
+      ->setData(Yaml::parse($yaml))
+      ->save();
+  }
+
+  /**
+   * Hide the specified field from user display.
+   *
+   * @param array $field_names
+   *   Fields to hide from user display.
+   */
+  private function hideUserDisplayFields(array $field_names) {
+    $config = $this->getUserDisplayConfig();
+
+    foreach ($field_names as $field_name) {
+      $config
+        ->set('hidden.' . $field_name, TRUE)
+        ->save();
+
+      $content = $config->get('content');
+      unset($content[$field_name]);
+
+      $config
+        ->set('content', $content)
+        ->save();
+    }
+  }
+
+}

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -10,6 +10,8 @@ use Drupal\user\UserInterface;
 use Drupal\yoti\YotiHelper;
 use Yoti\ActivityDetails;
 use Drupal\yoti\Models\YotiUserModel;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Component\Utility\Html;
 
 require_once __DIR__ . '/sdk/boot.php';
 
@@ -47,17 +49,17 @@ function yoti_entity_extra_field_info() {
 
   $fields = [];
   foreach ($map as $param => $label) {
-    $fields['user']['yoti']['display'][$param] = [
+    $fields['user']['user']['display'][$param] = [
       'label' => $label,
       'description' => $label,
       'weight' => 10,
     ];
   }
 
-  $fields['user']['yoti']['display']['yoti_unlink'] = [
+  $fields['user']['user']['display']['yoti_unlink'] = [
     'label' => t('Unlink'),
     'description' => t('Unlink Yoti account'),
-    'weight' => 5,
+    'weight' => 15,
   ];
 
   return $fields;
@@ -66,62 +68,74 @@ function yoti_entity_extra_field_info() {
 /**
  * Implements hook_ENTITY_TYPE_view() for user entities.
  */
-function yoti_user_view(array &$build, UserInterface $account) {
+function yoti_user_view(array &$build, UserInterface $account, EntityViewDisplayInterface $display, $view_mode) {
   $map = yoti_map_params();
 
   $user = \Drupal::currentUser();
-  $isAdmin = in_array('administrator', $user->getRoles(), TRUE);
-  $dbProfile = YotiUserModel::getYotiUserById($user->id());
+
+  $dbProfile = YotiUserModel::getYotiUserById($account->id());
   if (!$dbProfile) {
     return;
   }
 
   $userProfileArr = unserialize($dbProfile['data']);
 
-  foreach ($map as $param => $label) {
-    $value = isset($userProfileArr[$param]) ? $userProfileArr[$param] : '';
-    if ($param === ActivityDetails::ATTR_SELFIE) {
+  foreach ($map as $field => $label) {
+    // Ensure we only display visible fields.
+    if (!$display->getComponent($field)) {
+      continue;
+    }
+
+    $field_content = [];
+
+    if ($field === ActivityDetails::ATTR_SELFIE) {
       // Yoti user selfie file name.
       $selfieFileName = NULL;
       if (isset($userProfileArr[YotiHelper::ATTR_SELFIE_FILE_NAME])) {
         $selfieFileName = $userProfileArr[YotiHelper::ATTR_SELFIE_FILE_NAME];
       }
       $selfieFullPath = YotiHelper::uploadDir() . "/{$selfieFileName}";
-      if (!empty($selfieFileName) && file_exists($selfieFullPath)) {
-        $params = ['field' => 'selfie'];
-        if ($isAdmin) {
-          $params['user_id'] = $account->uid;
-        }
-        $selfieUrl = Url::fromRoute('yoti.bin-file', $params)->toString();
-        $value = '<img src="' . $selfieUrl . '" width="100" />';
-      }
-      else {
-        $value = '';
+      if (!empty($selfieFileName) && is_file($selfieFullPath)) {
+        $field_content = [
+          '#theme' => 'image',
+          '#uri' => Url::fromRoute('yoti.bin-file', [
+            'field' => 'selfie',
+            'user_id' => $account->id(),
+          ])->toString(),
+          '#width' => 100,
+        ];
       }
     }
-
-    if (!$value) {
-      $value = '<i>(empty)</i>';
+    elseif (!empty($userProfileArr[$field])) {
+      $field_content['#plain_text'] = $userProfileArr[$field];
     }
 
-    $build[$param] = [
+    if (empty($field_content)) {
+      $field_content['#markup'] = '<i>(empty)</i>';
+    }
+
+    $field_content['#prefix'] = '<h4 class="label">' . Html::escape($label) . '</h4> ';
+
+    $build[$field] = [
       '#type' => 'item',
-      '#markup' => '<h4 class="label">' . $label . '</h4> ' . $value,
+      '#id' => 'yoti-profile-' . $field,
+      'content' => $field_content,
     ];
   }
 
-  // Build Yoti unlink button.
-  $unlinkUrl = Url::fromRoute('yoti.unlink');
-  $link_options = [
-    'attributes' => [
-      'id' => [
-        'yoti-unlink-button',
+  // Ensure we only display unlink for the current user's profile.
+  if (($user->id() === $account->id()) && $display->getComponent('yoti_unlink')) {
+    // Build Yoti unlink button.
+    $unlinkUrl = Url::fromRoute('yoti.unlink');
+    $link_options = [
+      'attributes' => [
+        'id' => [
+          'yoti-unlink-button',
+        ],
       ],
-    ],
-  ];
-  $unlinkUrl->setOptions($link_options);
+    ];
+    $unlinkUrl->setOptions($link_options);
 
-  if ($user->id() === $account->id()) {
     $build['yoti_unlink'] = [
       '#type' => 'item',
       '#markup' => \Drupal::l(t('Unlink Yoti account'), $unlinkUrl),

--- a/yoti/yoti.routing.yml
+++ b/yoti/yoti.routing.yml
@@ -34,7 +34,8 @@ yoti.bin-file:
   defaults:
     _controller: '\Drupal\yoti\Controller\YotiStartController::binFile'
   requirements:
-    _permission: 'access content'
+    _custom_access: '\Drupal\yoti\Controller\YotiStartController::accessBinFile'
+    _csrf_token: 'TRUE'
   options:
     no_cache: TRUE
 


### PR DESCRIPTION
> Back-port #49 and #42. I've back-ported #42 as it is non-breaking and allows the user profile display to be configured (this is arguably a bug-fix too).

### Fixed
- Now displays corresponding user attributes on user profile pages instead of current user - This means attributes will be now viewable to anyone that have access to view user profiles.
   _Note: Please ensure you have reviewed which roles have `access user profiles` permission_
- Selfie image URL now has token.
- Allowing extra fields to be configured on the user display.

### Added
- User profile fields now have ID in format `yoti-profile-<field_key>`.

### Changed
- Using `#prefix` to add label so that it can be optionally removed in theme - the resulting markup should be unchanged (non-breaking).