### PR TITLE
SDK-1068: Use Drupal 7.67 Docker image

### DIFF
--- a/checkout-sdk.sh
+++ b/checkout-sdk.sh
@@ -3,10 +3,8 @@
 # this script puts the latest SDK in the working module directory
 #####################
 
-NAME="yoti-for-drupal-7.x-1.x-edge.zip"
 SDK_TAG=$1
 DEFAULT_SDK_TAG="2.0.0"
-SDK_RELATIVE_PATH="sdk"
 
 if [ "$SDK_TAG" = "" ]; then
     SDK_TAG=$DEFAULT_SDK_TAG
@@ -24,8 +22,8 @@ if [ ! -d "./yoti" ]; then
     exit
 fi
 
-cp -R "$SDK_RELATIVE_PATH" "./yoti/sdk"
-zip -r "$NAME" "./yoti"
+rm -fr ./yoti/sdk
+cp -R sdk ./yoti/sdk
 
 rm -rf sdk
 echo "Fetched PHP SDK TAG $SDK_TAG."

--- a/docker/app.base.dockerfile
+++ b/docker/app.base.dockerfile
@@ -1,8 +1,5 @@
 # from https://www.drupal.org/requirements/php#drupalversions
-FROM php:7.2-apache AS drupal_7_base
-
-# Fix for Error: Package 'php-XXX' has no installation candidate
-RUN rm /etc/apt/preferences.d/no-debian-php
+FROM drupal:7.67-apache AS drupal_7_base
 
 COPY default.conf /etc/apache2/sites-available/000-default.conf
 COPY ./keys/server.crt /etc/apache2/ssl/server.crt
@@ -10,50 +7,13 @@ COPY ./keys/server.key /etc/apache2/ssl/server.key
 
 RUN a2enmod rewrite ssl
 
-# install the PHP extensions we need
-RUN set -ex \
-	&& buildDeps=' \
-		libjpeg62-turbo-dev \
-		libpng-dev \
-		libpq-dev \
-	' \
-	&& apt-get update && apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-configure gd \
-		--with-jpeg-dir=/usr \
-		--with-png-dir=/usr \
-	&& docker-php-ext-install -j "$(nproc)" gd mbstring opcache pdo pdo_mysql pdo_pgsql zip \
-	&& apt-get update \
-	&& apt-get install -y git zip unzip vim nano php7.0-gd \
-# PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/local/lib/php/extensions/no-debug-non-zts-20151012/gd.so' - libjpeg.so.62: cannot open shared object file: No such file or directory in Unknown on line 0
-# PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/local/lib/php/extensions/no-debug-non-zts-20151012/pdo_pgsql.so' - libpq.so.5: cannot open shared object file: No such file or directory in Unknown on line 0
-	&& apt-mark manual \
-		libjpeg62-turbo \
-		libpq5 \
-	&& apt-get purge -y --auto-remove $buildDeps
-
-# set recommended PHP.ini settings
-# see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
-		echo 'opcache.memory_consumption=128'; \
-		echo 'opcache.interned_strings_buffer=8'; \
-		echo 'opcache.max_accelerated_files=4000'; \
-		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
-		echo 'opcache.enable_cli=1'; \
-	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
-
-# https://www.drupal.org/node/3060/release
 ENV DIRPATH /var/www/html
-ENV DRUPAL_VERSION 7.66
-ENV DRUPAL_MD5 fe1b9e18d7fc03fac6ff4e039ace5b0b
 
 WORKDIR $DIRPATH
 
-RUN curl -fSL "https://ftp.drupal.org/files/projects/drupal-${DRUPAL_VERSION}.tar.gz" -o drupal.tar.gz \
-	&& echo "${DRUPAL_MD5} *drupal.tar.gz" | md5sum -c - \
-	&& tar -xz --strip-components=1 -f drupal.tar.gz \
-	&& rm drupal.tar.gz \
-	&& chown -R www-data:www-data sites modules themes
+# Install dependencies.
+RUN apt-get update \
+  && apt-get install -y git zip unzip vim nano
 
 # Install Composer
 RUN EXPECTED_SIGNATURE="$(curl https://composer.github.io/installer.sig)" \

--- a/pack-plugin.sh
+++ b/pack-plugin.sh
@@ -1,48 +1,19 @@
 #!/bin/bash
-NAME="yoti-for-drupal-7.x-1.x-edge.zip"
 
 SDK_TAG=$1
-DEFAULT_SDK_TAG='2.0.0'
+
+NAME="yoti-for-drupal-7.x-1.x-edge.zip"
 SDK_RELATIVE_PATH="sdk"
 
-if [ "$SDK_TAG" = "" ]; then
-    SDK_TAG=$DEFAULT_SDK_TAG
-fi
-
-echo "Pulling PHP SDK TAG $SDK_TAG.zip ..."
-
-curl https://github.com/getyoti/yoti-php-sdk/archive/$SDK_TAG.zip -O -L
-unzip $SDK_TAG.zip -d sdk
-mv sdk/yoti-php-sdk-$SDK_TAG/src/* sdk
-rm -rf sdk/yoti-php-sdk-$SDK_TAG
-
-if [ ! -d "./yoti" ]; then
-    echo "ERROR: Must be in directory containing ./yoti folder"
-    exit
-fi
-
-if [ ! -d "$SDK_RELATIVE_PATH" ]; then
-    "ERROR: Could not find SDK in $SDK_RELATIVE_PATH"
-    exit
-fi
+./checkout-sdk.sh "$SDK_TAG"
 
 echo "Packing plugin ..."
-
-# move sdk symlink (used in symlink-plugin-to-site.sh)
-sym_exist=0
-if [ -L "./yoti/sdk" ]; then
-    mv "./yoti/sdk" "./__sdk-sym";
-    sym_exist=1
-fi
 
 cp -R "$SDK_RELATIVE_PATH" "./yoti/sdk"
 zip -r "$NAME" "./yoti"
 rm -rf "./yoti/sdk"
 
-# move symlink back
-if [ $sym_exist ]; then
-    mv "./__sdk-sym" "./yoti/sdk"
-fi
 rm -rf sdk
+
 echo "Plugin packed. File $NAME created."
 echo ""

--- a/yoti/yoti.info
+++ b/yoti/yoti.info
@@ -3,6 +3,5 @@ description = "A simple module to allow users to login/signup with their Yoti ac
 package = Yoti
 core = 7.x
 configure = admin/config/people/yoti
-datestamp = "1459503240"
 
 files[] = tests/yoti.test


### PR DESCRIPTION
### Changed
- Using Drupal 7.67 Docker image instead of custom Dockerfile
- Removed timestamp from info file (this will be added automatically by Drupal)