### PR TITLE
SDK-1069: User profile

### DIFF
--- a/yoti/tests/yoti.test
+++ b/yoti/tests/yoti.test
@@ -128,6 +128,7 @@ class YotiTest extends DrupalWebTestCase {
       'uid' => $this->linkedUser->uid,
       'identifier' => 'some-remember-me-id',
       'data' => serialize(array(
+        'full_name' => 'test full name',
         'selfie_filename' => $this->selfieFilePath,
       )),
     ])->execute();
@@ -273,20 +274,8 @@ class YotiTest extends DrupalWebTestCase {
    * Test Unlink Form.
    */
   public function testUnlinkForm() {
-    // Log in as unlinked user.
-    $this->drupalLogin($this->unlinkedUser);
-
-    // Check selfie exists and cannot be viewed by another user.
-    $this->assertTrue(is_file($this->selfieFilePath), 'Check selfie exists');
-    $this->drupalGet('yoti/bin-file', array('query' => array('field' => 'selfie')));
-    $this->assertNoRaw('test_selfie_contents');
-
     // Log in as linked user.
     $this->drupalLogin($this->linkedUser);
-
-    // Check selfie can be viewed by current linked user.
-    $this->drupalGet('yoti/bin-file', array('query' => array('field' => 'selfie')));
-    $this->assertRaw('test_selfie_contents');
 
     // Visit user profile.
     $this->drupalGet('user');
@@ -300,15 +289,6 @@ class YotiTest extends DrupalWebTestCase {
         ':class' => 'button',
       ),
       'Check unlink Yoti Account link'
-    );
-
-    // Check selfie img tag exists.
-    $this->assertElementByXpath(
-      "//img[contains(@src,:img_src)]",
-      array(
-        ':img_src' => '/yoti/bin-file?field=selfie',
-      ),
-      'Check selfie exists'
     );
 
     $this->clickLink('Unlink Yoti Account');
@@ -330,6 +310,63 @@ class YotiTest extends DrupalWebTestCase {
     // Check selfie was removed.
     clearstatcache(NULL, $this->selfieFilePath);
     $this->assertFalse(is_file($this->selfieFilePath), 'Check selfie has been deleted');
+  }
+
+  /**
+   * Test user profile page.
+   */
+  public function testProfile() {
+    // Log in as unlinked user.
+    $this->drupalLogin($this->unlinkedUser);
+
+    // Check selfie exists and cannot be viewed by another user.
+    $this->assertTrue(is_file($this->selfieFilePath), 'Check selfie exists');
+    $this->drupalGet('yoti/bin-file', array(
+      'query' => array(
+        'field' => 'selfie',
+        'user_id' => $this->linkedUser->uid,
+      ),
+    ));
+    $this->assertNoRaw('test_selfie_contents');
+    $this->assertResponse(404);
+
+    // Log in as linked user.
+    $this->drupalLogin($this->linkedUser);
+
+    // Visit user profile.
+    $this->drupalGet('user');
+
+    // Check full name is present.
+    $this->assertText('test full name');
+
+    // Check all attributes are present.
+    $attribute_ids = array(
+      'yoti-profile-selfie',
+      'yoti-profile-full_name',
+      'yoti-profile-given_names',
+      'yoti-profile-family_name',
+      'yoti-profile-phone_number',
+      'yoti-profile-email_address',
+      'yoti-profile-date_of_birth',
+      'yoti-profile-age_verified',
+      'yoti-profile-postal_address',
+      'yoti-profile-gender',
+      'yoti-profile-nationality',
+    );
+    foreach ($attribute_ids as $attribute_id) {
+      $this->assertElementByXpath(
+        '//div[@id=:id]',
+        array(':id' => $attribute_id),
+        sprintf('Check #%s element exists', $attribute_id));
+    }
+
+    // Check selfie can be viewed by current linked user.
+    $result = $this->xpath("//div[@id='yoti-profile-selfie']//img");
+    $url = parse_url((string) $result[0]['src']);
+    parse_str($url['query'], $query);
+    $this->drupalGet(trim($url['path'], '/'), array('query' => $query));
+    $this->assertRaw('test_selfie_contents');
+    $this->assertResponse(200);
   }
 
   /**

--- a/yoti/tests/yoti.test
+++ b/yoti/tests/yoti.test
@@ -135,6 +135,11 @@ class YotiTest extends DrupalWebTestCase {
 
     // Create an unlinked user.
     $this->unlinkedUser = $this->drupalCreateUser();
+
+    // Create a user that can view user profiles.
+    $this->userWithUserProfilesPermission = $this->drupalCreateUser(array(
+      'access user profiles',
+    ));
   }
 
   /**
@@ -330,6 +335,11 @@ class YotiTest extends DrupalWebTestCase {
     $this->assertNoRaw('test_selfie_contents');
     $this->assertResponse(404);
 
+    // Log in as user with access to view user profiles.
+    $this->drupalLogin($this->userWithUserProfilesPermission);
+    $this->drupalGet('user/' . $this->linkedUser->uid);
+    $this->assertProfileSelfieCanBeViewed();
+
     // Log in as linked user.
     $this->drupalLogin($this->linkedUser);
 
@@ -360,13 +370,7 @@ class YotiTest extends DrupalWebTestCase {
         sprintf('Check #%s element exists', $attribute_id));
     }
 
-    // Check selfie can be viewed by current linked user.
-    $result = $this->xpath("//div[@id='yoti-profile-selfie']//img");
-    $url = parse_url((string) $result[0]['src']);
-    parse_str($url['query'], $query);
-    $this->drupalGet(trim($url['path'], '/'), array('query' => $query));
-    $this->assertRaw('test_selfie_contents');
-    $this->assertResponse(200);
+    $this->assertProfileSelfieCanBeViewed();
   }
 
   /**
@@ -461,6 +465,18 @@ class YotiTest extends DrupalWebTestCase {
       strstr($form['#attached']['css'][0]['data'], 'yoti/css/yoti.css'),
       'Check CSS is attached to form'
     );
+  }
+
+  /**
+   * Assert that the selfie on the profile can be viewed.
+   */
+  private function assertProfileSelfieCanBeViewed() {
+    $result = $this->xpath("//div[@id='yoti-profile-selfie']//img");
+    $url = parse_url((string) $result[0]['src']);
+    parse_str($url['query'], $query);
+    $this->drupalGet(trim($url['path'], '/'), array('query' => $query));
+    $this->assertRaw('test_selfie_contents');
+    $this->assertResponse(200);
   }
 
 }

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -280,11 +280,10 @@ function yoti_permission() {
  */
 function yoti_user_view($account, $view_mode, $langcode) {
   global $user;
+  $current = $user;
 
   $map = yoti_map_params();
 
-  $current = $user;
-  $isAdmin = in_array('administrator', $current->roles, TRUE);
   $dbProfile = YotiHelper::getYotiUserProfile($account->uid);
   if (!$dbProfile) {
     return;
@@ -292,35 +291,37 @@ function yoti_user_view($account, $view_mode, $langcode) {
 
   $dbProfile = unserialize($dbProfile['data']);
 
-  foreach ($map as $param => $label) {
-    $value = isset($dbProfile[$param]) ? $dbProfile[$param] : '';
-    if ($param === ActivityDetails::ATTR_SELFIE && !empty($dbProfile['selfie_filename'])) {
+  foreach ($map as $field => $label) {
+    if ($field === ActivityDetails::ATTR_SELFIE && !empty($dbProfile['selfie_filename'])) {
       $selfieFullPath = YotiHelper::selfieFilePath($dbProfile['selfie_filename']);
       if (is_file($selfieFullPath)) {
-        $params = ['field' => 'selfie'];
-        if ($isAdmin) {
+        $params = [
+          'field' => 'selfie',
+          'token' => drupal_get_token('yoti_selfie'),
+        ];
+        if (user_access('access user profiles')) {
           $params['user_id'] = $account->uid;
         }
         $selfieUrl = url('/yoti/bin-file', ['query' => $params]);
-        $value = '<img src="' . $selfieUrl . '" width="100" />';
+        $field_content = array(
+          '#theme' => 'image',
+          '#width' => '100',
+          '#path' => $selfieUrl,
+        );
       }
-      else {
-        $value = '';
-      }
+    }
+    else {
+      $field_content = array(
+        '#markup' => isset($dbProfile[$field]) ? check_plain($dbProfile[$field]) : '<i>(empty)</i>',
+      );
     }
 
-    // Format date of birth.
-    if ($param === ActivityDetails::ATTR_DATE_OF_BIRTH && !empty($value)) {
-      $value = date('d-m-Y', strtotime($value));
-    }
+    $field_content['#prefix'] = '<label>' . check_plain($label) . '</label>';
 
-    if (!$value) {
-      $value = '<i>(empty)</i>';
-    }
-
-    $account->content['summary'][$param] = [
+    $account->content['summary'][$field] = [
       '#type' => 'item',
-      '#markup' => '<label>' . $label . '</label>' . $value,
+      '#id' => 'yoti-profile-' . $field,
+      'content' => $field_content,
     ];
   }
 

--- a/yoti/yoti.pages.inc
+++ b/yoti/yoti.pages.inc
@@ -57,12 +57,19 @@ function yoti_unlink_submit() {
 function yoti_bin_file() {
   global $user;
 
+  // Check that request token is valid before serving the image.
+  if (!isset($_GET['token']) || !drupal_valid_token($_GET['token'], 'yoti_selfie')) {
+    drupal_not_found();
+    drupal_exit();
+  }
+
   $current = $user;
-  $isAdmin = in_array('administrator', $current->roles, TRUE);
-  $userId = (!empty($_GET['user_id']) && $isAdmin) ? (int) $_GET['user_id'] : $current->uid;
+  $userId = (!empty($_GET['user_id']) && user_access('access user profiles')) ? (int) $_GET['user_id'] : $current->uid;
+
   $dbProfile = YotiHelper::getYotiUserProfile($userId);
   if (!$dbProfile) {
-    return;
+    drupal_not_found();
+    drupal_exit();
   }
 
   $dbProfile = unserialize($dbProfile['data']);
@@ -74,12 +81,14 @@ function yoti_bin_file() {
 
   $field = ($field === 'selfie') ? 'selfie_filename' : $field;
   if (!$dbProfile || !array_key_exists($field, $dbProfile)) {
-    return;
+    drupal_not_found();
+    drupal_exit();
   }
 
   $file = YotiHelper::selfieFilePath($dbProfile[$field]);
   if (!is_file($file)) {
-    return;
+    drupal_not_found();
+    drupal_exit();
   }
 
   $type = 'image/png';


### PR DESCRIPTION
> Back-ported from #54.

### Fixed
- Selfies now viewable to anyone that have access to view user profiles - the selfie would previously only show to the current logged in user and administrators, causing broken images on profile pages for anyone with privilege to view user profiles.
   _Note: Please ensure you have reviewed which roles have `view user profiles` permission_
- Selfie image URL now has token.

### Added
- User profile fields now have ID in format `yoti-profile-<field_key>`.

### Changed
- Using `#prefix` to add label so that it can be optionally removed in theme - the resulting markup should be unchanged (non-breaking).