### PR TITLE
SDK-1066: Add new selfie permission

### DIFF
--- a/yoti/Readme.md
+++ b/yoti/Readme.md
@@ -130,6 +130,12 @@ function my_module_user_view_alter(&$build) {
 You can also control who can view user profiles using permissions
 at `/admin/people/permissions`.
 
+## Permissions
+
+* `administer yoti`: Allow users to configure the Yoti module.
+* `view yoti selfie images`: Allow users to view other user selfie images.
+  Users can always view their own selfie images.
+
 ## API Coverage
 
 * Activity Details

--- a/yoti/YotiHelper.php
+++ b/yoti/YotiHelper.php
@@ -49,6 +49,16 @@ class YotiHelper {
   const YOTI_HUB_URL = 'https://hub.yoti.com';
 
   /**
+   * Permission to view Yoti selfie images.
+   */
+  const YOTI_PERMISSION_VIEW_SELFIE = 'view yoti selfie images';
+
+  /**
+   * Field for selfie bin file.
+   */
+  const YOTI_BIN_FIELD_SELFIE = 'selfie';
+
+  /**
    * Yoti module config.
    *
    * @var array

--- a/yoti/tests/yoti.test
+++ b/yoti/tests/yoti.test
@@ -124,22 +124,10 @@ class YotiTest extends DrupalWebTestCase {
 
     // Create a linked user.
     $this->linkedUser = $this->drupalCreateUser();
-    db_insert(YotiHelper::YOTI_USER_TABLE_NAME)->fields([
-      'uid' => $this->linkedUser->uid,
-      'identifier' => 'some-remember-me-id',
-      'data' => serialize(array(
-        'full_name' => 'test full name',
-        'selfie_filename' => $this->selfieFilePath,
-      )),
-    ])->execute();
+    $this->linkUser($this->linkedUser->uid);
 
     // Create an unlinked user.
     $this->unlinkedUser = $this->drupalCreateUser();
-
-    // Create a user that can view user profiles.
-    $this->userWithUserProfilesPermission = $this->drupalCreateUser(array(
-      'access user profiles',
-    ));
   }
 
   /**
@@ -158,6 +146,20 @@ class YotiTest extends DrupalWebTestCase {
     }
 
     parent::teardown();
+  }
+
+  /**
+   * Links provided user.
+   */
+  private function linkUser($uid) {
+    db_insert(YotiHelper::YOTI_USER_TABLE_NAME)->fields([
+      'uid' => $uid,
+      'identifier' => 'some-remember-me-id',
+      'data' => serialize(array(
+        'full_name' => 'test full name',
+        'selfie_filename' => $this->selfieFilePath,
+      )),
+    ])->execute();
   }
 
   /**
@@ -324,9 +326,9 @@ class YotiTest extends DrupalWebTestCase {
   }
 
   /**
-   * Test user profile page.
+   * Test user profile permissions.
    */
-  public function testProfile() {
+  public function testProfilePermissions() {
     // Log in as unlinked user.
     $this->drupalLogin($this->unlinkedUser);
 
@@ -334,18 +336,44 @@ class YotiTest extends DrupalWebTestCase {
     $this->assertTrue(is_file($this->selfieFilePath), 'Check selfie exists');
     $this->drupalGet('yoti/bin-file', array(
       'query' => array(
-        'field' => 'selfie',
+        'field' => YotiHelper::YOTI_BIN_FIELD_SELFIE,
         'user_id' => $this->linkedUser->uid,
       ),
     ));
     $this->assertNoRaw('test_selfie_contents');
     $this->assertResponse(404);
 
-    // Log in as user with access to view user profiles.
-    $this->drupalLogin($this->userWithUserProfilesPermission);
+    // Log in as user with access to view user profiles and selfies.
+    $userWithUserProfilesAndSelfiePermission = $this->drupalCreateUser(array(
+      'access user profiles',
+      YotiHelper::YOTI_PERMISSION_VIEW_SELFIE,
+    ));
+    $this->drupalLogin($userWithUserProfilesAndSelfiePermission);
     $this->drupalGet('user/' . $this->linkedUser->uid);
     $this->assertProfileSelfieCanBeViewed();
 
+    // Log in as user with access to view user profiles.
+    $userWithUserProfilesPermission = $this->drupalCreateUser(array(
+      'access user profiles',
+    ));
+    $this->linkUser($userWithUserProfilesPermission->uid);
+    $this->drupalLogin($userWithUserProfilesPermission);
+    $this->drupalGet('user/' . $this->linkedUser->uid);
+    $this->assertNoRaw('yoti/bin-file');
+
+    // Check user without selfie permission cannot see other selfie images.
+    $this->drupalGet('user');
+    $url = $this->getSelfieUrl();
+    $url['query']['user_id'] = $this->linkedUser->uid;
+    $this->drupalGet(trim($url['path'], '/'), array('query' => $url['query']));
+    $this->assertNoRaw('test_selfie_contents');
+    $this->assertResponse(403);
+  }
+
+  /**
+   * Test user profile display.
+   */
+  public function testProfileDisplay() {
     // Log in as linked user.
     $this->drupalLogin($this->linkedUser);
 
@@ -474,13 +502,28 @@ class YotiTest extends DrupalWebTestCase {
   }
 
   /**
+   * Get selfie URL on current page.
+   *
+   * @return array
+   *   URL consisting of `path` and `query`
+   */
+  private function getSelfieUrl() {
+    $result = $this->xpath("//div[@id='yoti-profile-selfie']//img");
+    $url_parts = parse_url((string) $result[0]['src']);
+    parse_str($url_parts['query'], $query);
+
+    return array(
+      'path' => $url_parts['path'],
+      'query' => $query,
+    );
+  }
+
+  /**
    * Assert that the selfie on the profile can be viewed.
    */
   private function assertProfileSelfieCanBeViewed() {
-    $result = $this->xpath("//div[@id='yoti-profile-selfie']//img");
-    $url = parse_url((string) $result[0]['src']);
-    parse_str($url['query'], $query);
-    $this->drupalGet(trim($url['path'], '/'), array('query' => $query));
+    $url = $this->getSelfieUrl();
+    $this->drupalGet(trim($url['path'], '/'), array('query' => $url['query']));
     $this->assertRaw('test_selfie_contents');
     $this->assertResponse(200);
   }

--- a/yoti/yoti.install
+++ b/yoti/yoti.install
@@ -166,3 +166,13 @@ function yoti_uninstall() {
 function yoti_enable() {
   drupal_set_message(t('Yoti enabled. <a href="@path">Check module settings</a>.', ['@path' => url('admin/config/people/yoti')]));
 }
+
+/**
+ * Grant 'view yoti selfie images' permission to administrator role.
+ */
+function yoti_update_7001() {
+  $rid = variable_get('user_admin_role', 0);
+  if ($rid) {
+    user_role_grant_permissions($rid, array(YotiHelper::YOTI_PERMISSION_VIEW_SELFIE));
+  }
+}

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -255,6 +255,9 @@ function yoti_permission() {
   $items['administer yoti'] = [
     'title' => 'Administer Yoti Module settings',
   ];
+  $items[YotiHelper::YOTI_PERMISSION_VIEW_SELFIE] = [
+    'title' => 'View Yoti selfie images',
+  ];
   return $items;
 }
 
@@ -276,13 +279,20 @@ function yoti_user_view($account, $view_mode, $langcode) {
 
   foreach ($map as $field => $label) {
     if ($field === Profile::ATTR_SELFIE && !empty($dbProfile['selfie_filename'])) {
+      // Hide selfie for users that don't have access.
+      if (!user_access(YotiHelper::YOTI_PERMISSION_VIEW_SELFIE) &&
+        $current->uid != $account->uid
+      ) {
+        continue;
+      }
+
       $selfieFullPath = YotiHelper::selfieFilePath($dbProfile['selfie_filename']);
       if (is_file($selfieFullPath)) {
         $params = [
-          'field' => 'selfie',
+          'field' => YotiHelper::YOTI_BIN_FIELD_SELFIE,
           'token' => drupal_get_token('yoti_selfie'),
         ];
-        if (user_access('access user profiles')) {
+        if (user_access(YotiHelper::YOTI_PERMISSION_VIEW_SELFIE)) {
           $params['user_id'] = $account->uid;
         }
         $selfieUrl = url('/yoti/bin-file', ['query' => $params]);

--- a/yoti/yoti.pages.inc
+++ b/yoti/yoti.pages.inc
@@ -79,7 +79,7 @@ function yoti_bin_file() {
       break;
 
     default:
-      $canAccess = user_access('access user profiles');
+      $canAccess = user_access('administer users');
   }
 
   // Use requested user ID if provided and default to current user.

--- a/yoti/yoti.pages.inc
+++ b/yoti/yoti.pages.inc
@@ -56,15 +56,40 @@ function yoti_unlink_submit() {
  */
 function yoti_bin_file() {
   global $user;
+  $current = $user;
 
-  // Check that request token is valid before serving the image.
+  // Check that request token is valid before serving the bin file.
   if (!isset($_GET['token']) || !drupal_valid_token($_GET['token'], 'yoti_selfie')) {
     drupal_not_found();
     drupal_exit();
   }
 
-  $current = $user;
-  $userId = (!empty($_GET['user_id']) && user_access('access user profiles')) ? (int) $_GET['user_id'] : $current->uid;
+  // Field must be provided to fetch a bin file.
+  if (empty($_GET['field'])) {
+    drupal_not_found();
+    drupal_exit();
+  }
+  $field = $_GET['field'];
+
+  // Check access and set field based on requested field name.
+  switch ($field) {
+    case YotiHelper::YOTI_BIN_FIELD_SELFIE:
+      $canAccess = user_access(YotiHelper::YOTI_PERMISSION_VIEW_SELFIE);
+      $field = 'selfie_filename';
+      break;
+
+    default:
+      $canAccess = user_access('access user profiles');
+  }
+
+  // Use requested user ID if provided and default to current user.
+  $userId = !empty($_GET['user_id']) ? (int) $_GET['user_id'] : (int) $current->uid;
+
+  // Prevent access to other user files for users without permission.
+  if (($userId != $current->uid) && !$canAccess) {
+    drupal_access_denied();
+    drupal_exit();
+  }
 
   $dbProfile = YotiHelper::getYotiUserProfile($userId);
   if (!$dbProfile) {
@@ -74,12 +99,6 @@ function yoti_bin_file() {
 
   $dbProfile = unserialize($dbProfile['data']);
 
-  $field = NULL;
-  if (!empty($_GET['field'])) {
-    $field = $_GET['field'];
-  }
-
-  $field = ($field === 'selfie') ? 'selfie_filename' : $field;
   if (!$dbProfile || !array_key_exists($field, $dbProfile)) {
     drupal_not_found();
     drupal_exit();


### PR DESCRIPTION
### Added
- Permission `view yoti selfie images`: Allow users to view other user selfie images. This permission is automatically granted to the admin role.
  _Note: Users can always view their own selfie images._