### PR TITLE
SDK-1066: Add new selfie permission

### DIFF
--- a/yoti/Readme.md
+++ b/yoti/Readme.md
@@ -119,6 +119,12 @@ This can be customised at `/admin/config/people/accounts/display`.
 You can also control who can view user profiles using permissions
 at `/admin/people/permissions`.
 
+## Permissions
+
+* `administer yoti`: Allow users to configure the Yoti module.
+* `view yoti selfie images`: Allow users to view other user selfie images.
+  Users can always view their own selfie images.
+
 ## API Coverage
 
 * Activity Details

--- a/yoti/src/Controller/YotiStartController.php
+++ b/yoti/src/Controller/YotiStartController.php
@@ -98,15 +98,22 @@ class YotiStartController extends ControllerBase {
    *
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Run access checks for this account.
+   * @param string $field
+   *   The field used to retrive the bin file.
    *
    * @return \Drupal\Core\Access\AccessResult
    *   If account can view target user isAllowed() will be TRUE.
    */
-  public static function accessBinFile(AccountInterface $account) {
-    if ($targetUser = self::getTargetUser($account)) {
-      return AccessResult::allowedIf($targetUser->access('view', $account));
+  public static function accessBinFile(AccountInterface $account, $field) {
+    $targetUser = self::getTargetUser($account);
+    $targetUserIsCurrent = $targetUser->id() === $account->id();
+
+    if ($field === 'selfie') {
+      return AccessResult::allowedIfHasPermission($account, YotiHelper::YOTI_PERMISSION_VIEW_SELFIE)
+        ->orIf(AccessResult::allowedIf($targetUserIsCurrent));
     }
-    return AccessResult::neutral();
+
+    return AccessResult::allowedIf($targetUser->access('view', $account));
   }
 
   /**

--- a/yoti/src/Controller/YotiStartController.php
+++ b/yoti/src/Controller/YotiStartController.php
@@ -113,7 +113,7 @@ class YotiStartController extends ControllerBase {
         ->orIf(AccessResult::allowedIf($targetUserIsCurrent));
     }
 
-    return AccessResult::allowedIf($targetUser->access('view', $account));
+    return AccessResult::allowedIf($targetUser->access('update', $account));
   }
 
   /**

--- a/yoti/src/Controller/YotiStartController.php
+++ b/yoti/src/Controller/YotiStartController.php
@@ -63,7 +63,7 @@ class YotiStartController extends ControllerBase {
     // Unserialize Yoti user data.
     $userProfileArr = unserialize($dbProfile['data']);
 
-    $field = ($field === 'selfie') ? 'selfie_filename' : $field;
+    $field = ($field === YotiHelper::YOTI_BIN_FIELD_SELFIE) ? 'selfie_filename' : $field;
     if (!is_array($userProfileArr) || !array_key_exists($field, $userProfileArr)) {
       throw new NotFoundHttpException();
     }
@@ -108,7 +108,7 @@ class YotiStartController extends ControllerBase {
     $targetUser = self::getTargetUser($account);
     $targetUserIsCurrent = $targetUser->id() === $account->id();
 
-    if ($field === 'selfie') {
+    if ($field === YotiHelper::YOTI_BIN_FIELD_SELFIE) {
       return AccessResult::allowedIfHasPermission($account, YotiHelper::YOTI_PERMISSION_VIEW_SELFIE)
         ->orIf(AccessResult::allowedIf($targetUserIsCurrent));
     }

--- a/yoti/src/YotiHelper.php
+++ b/yoti/src/YotiHelper.php
@@ -57,6 +57,11 @@ class YotiHelper {
   const YOTI_HUB_URL = 'https://hub.yoti.com';
 
   /**
+   * Permission to view Yoti selfie images.
+   */
+  const YOTI_PERMISSION_VIEW_SELFIE = 'view yoti selfie images';
+
+  /**
    * MySQL Database connection.
    *
    * @var \Drupal\Core\Database\Driver\mysql\Connection

--- a/yoti/src/YotiHelper.php
+++ b/yoti/src/YotiHelper.php
@@ -62,6 +62,11 @@ class YotiHelper {
   const YOTI_PERMISSION_VIEW_SELFIE = 'view yoti selfie images';
 
   /**
+   * Field for selfie bin file.
+   */
+  const YOTI_BIN_FIELD_SELFIE = 'selfie';
+
+  /**
    * MySQL Database connection.
    *
    * @var \Drupal\Core\Database\Driver\mysql\Connection

--- a/yoti/tests/src/Functional/YotiProfileTest.php
+++ b/yoti/tests/src/Functional/YotiProfileTest.php
@@ -34,10 +34,24 @@ class YotiProfileTest extends YotiBrowserTestBase {
    * Test viewing profile as user with only profile permission.
    */
   public function testProfileLinkedAsUserWithProfilePermission() {
-    $userWithUserProfilePermission = $this->drupalCreateUser([
+    $userWithUserProfilePermission = $this->createLinkedUser([
       'access user profiles',
     ]);
     $this->drupalLogin($userWithUserProfilePermission);
+
+    // Check user can view own profile and selfie.
+    $this->drupalGet('user/' . $userWithUserProfilePermission->id());
+    $this->assertProfileFields(yoti_map_params());
+    $this->assertSelfieImage();
+
+    // Check they cannot see other user profile images.
+    $url = $this->getSelfieImageUrl();
+    $url['query']['user_id'] = $this->linkedUser->id();
+    $this->drupalGet(trim($url['path'], '/'), ['query' => $url['query']]);
+    $this->assertSession()->statusCodeEquals(403);
+    $this->assertSession()->responseNotContains('test_selfie_contents');
+
+    // Check other users profile.
     $this->drupalGet('user/' . $this->linkedUser->id());
 
     $profile_data = yoti_map_params();
@@ -135,14 +149,15 @@ class YotiProfileTest extends YotiBrowserTestBase {
   }
 
   /**
-   * Assert that the selfie image is present and can be viewed.
+   * Get selfie url from current page.
+   *
+   * @return array
+   *   Parsed URL consisting of `path` and `query`.
    */
-  private function assertSelfieImage() {
-    $assert = $this->assertSession();
-
+  private function getSelfieImageUrl() {
     // Check selfie image is present.
     $selfie_selector = "img[src*='/yoti/bin-file/selfie'][width='100']";
-    $assert->elementExists('css', $selfie_selector);
+    $this->assertSession()->elementExists('css', $selfie_selector);
 
     // Visit selfie using img src attribute.
     $selfie_src_attr = $this
@@ -150,13 +165,25 @@ class YotiProfileTest extends YotiBrowserTestBase {
       ->getPage()
       ->find('css', $selfie_selector)
       ->getAttribute('src');
-    $selfie_url = htmlspecialchars_decode($selfie_src_attr);
 
-    $path = parse_url($selfie_url, PHP_URL_PATH);
-    parse_str(parse_url($selfie_url, PHP_URL_QUERY), $query_params);
+    $url = htmlspecialchars_decode($selfie_src_attr);
+    $path = parse_url($url, PHP_URL_PATH);
+    parse_str(parse_url($url, PHP_URL_QUERY), $query_params);
 
-    $this->drupalGet(trim($path, '/'), ['query' => $query_params]);
-    $assert->responseContains('test_selfie_contents');
+    return [
+      'path' => $path,
+      'query' => $query_params,
+    ];
+  }
+
+  /**
+   * Assert that the selfie image on current page is present and can be viewed.
+   */
+  private function assertSelfieImage() {
+    $url = $this->getSelfieImageUrl();
+
+    $this->drupalGet(trim($url['path'], '/'), ['query' => $url['query']]);
+    $this->assertSession()->responseContains('test_selfie_contents');
 
     // Go back to previous page.
     $this->getSession()->back();

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -103,7 +103,7 @@ function yoti_user_view(array &$build, UserInterface $account, EntityViewDisplay
         $field_content = [
           '#theme' => 'image',
           '#uri' => Url::fromRoute('yoti.bin-file', [
-            'field' => 'selfie',
+            'field' => YotiHelper::YOTI_BIN_FIELD_SELFIE,
             'user_id' => $account->id(),
           ])->toString(),
           '#width' => 100,

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -87,6 +87,12 @@ function yoti_user_view(array &$build, UserInterface $account, EntityViewDisplay
     $field_content = [];
 
     if ($field === Profile::ATTR_SELFIE) {
+      if ($user->id() !== $account->id() &&
+        !$user->hasPermission(YotiHelper::YOTI_PERMISSION_VIEW_SELFIE)
+      ) {
+        continue;
+      }
+
       // Yoti user selfie file name.
       $selfieFileName = NULL;
       if (isset($userProfileArr[YotiHelper::ATTR_SELFIE_FILE_NAME])) {

--- a/yoti/yoti.permissions.yml
+++ b/yoti/yoti.permissions.yml
@@ -2,3 +2,6 @@ administer yoti:
   title: 'Administer Yoti'
   description: 'Administer the Yoti module'
   restrict access: true
+view yoti selfie images:
+  title: 'View Yoti Selfie Images'
+  description: 'Allows users to see other user selfie images'


### PR DESCRIPTION
### Added
- Permission `view yoti selfie images`: Allow users to view other user selfie images. This permission is automatically granted to the admin role.
  _Note: Users can always view their own selfie images._