### PR TITLE
SDK-1066: Add new selfie permission

### DIFF
--- a/yoti/Readme.md
+++ b/yoti/Readme.md
@@ -119,6 +119,12 @@ This can be customised at `/admin/config/people/accounts/display`.
 You can also control who can view user profiles using permissions
 at `/admin/people/permissions`.
 
+## Permissions
+
+* `administer yoti`: Allow users to configure the Yoti module.
+* `view yoti selfie images`: Allow users to view other user selfie images.
+  Users can always view their own selfie images.
+
 ## API Coverage
 
 * Activity Details

--- a/yoti/src/YotiHelper.php
+++ b/yoti/src/YotiHelper.php
@@ -37,19 +37,29 @@ class YotiHelper {
   const YOTI_PEM_FILE_UPLOAD_LOCATION = 'private://yoti';
 
   /**
-     * Yoti selfie filename attribute.
-     */
+   * Yoti selfie filename attribute.
+   */
   const ATTR_SELFIE_FILE_NAME = 'selfie_filename';
 
   /**
-     * Yoti Drupal SDK identifier.
-     */
+   * Yoti Drupal SDK identifier.
+   */
   const SDK_IDENTIFIER = 'Drupal';
 
   /**
-     * Age verification attribute.
-     */
+   * Age verification attribute.
+   */
   const AGE_VERIFICATION_ATTR = 'age_verified';
+
+  /**
+   * Permission to view Yoti selfie images.
+   */
+  const YOTI_PERMISSION_VIEW_SELFIE = 'view yoti selfie images';
+
+  /**
+   * Field for selfie bin file.
+   */
+  const YOTI_BIN_FIELD_SELFIE = 'selfie';
 
   /**
    * MySQL Database connection.

--- a/yoti/yoti.module
+++ b/yoti/yoti.module
@@ -89,6 +89,12 @@ function yoti_user_view(array &$build, UserInterface $account, EntityViewDisplay
     $field_content = [];
 
     if ($field === ActivityDetails::ATTR_SELFIE) {
+      if ($user->id() !== $account->id() &&
+        !$user->hasPermission(YotiHelper::YOTI_PERMISSION_VIEW_SELFIE)
+      ) {
+        continue;
+      }
+
       // Yoti user selfie file name.
       $selfieFileName = NULL;
       if (isset($userProfileArr[YotiHelper::ATTR_SELFIE_FILE_NAME])) {
@@ -99,7 +105,7 @@ function yoti_user_view(array &$build, UserInterface $account, EntityViewDisplay
         $field_content = [
           '#theme' => 'image',
           '#uri' => Url::fromRoute('yoti.bin-file', [
-            'field' => 'selfie',
+            'field' => YotiHelper::YOTI_BIN_FIELD_SELFIE,
             'user_id' => $account->id(),
           ])->toString(),
           '#width' => 100,

--- a/yoti/yoti.permissions.yml
+++ b/yoti/yoti.permissions.yml
@@ -2,3 +2,6 @@ administer yoti:
   title: 'Administer Yoti'
   description: 'Administer the Yoti module'
   restrict access: true
+view yoti selfie images:
+  title: 'View Yoti Selfie Images'
+  description: 'Allows users to see other user selfie images'


### PR DESCRIPTION
> Back-port of #67 

### Added
- Permission `view yoti selfie images`: Allow users to view other user selfie images. This permission is automatically granted to the admin role.
  _Note: Users can always view their own selfie images._