### PR TITLE
SDK-941: Set current user to anonymous in test

### DIFF
--- a/yoti/tests/yoti.test
+++ b/yoti/tests/yoti.test
@@ -430,6 +430,9 @@ class YotiTest extends DrupalWebTestCase {
    * Test Register Form.
    */
   public function testRegisterForm() {
+    global $user;
+    $user = drupal_anonymous_user();
+
     module_load_include('inc', 'yoti', 'yoti.pages');
 
     // Set session data.

--- a/yoti/tests/yoti.test
+++ b/yoti/tests/yoti.test
@@ -294,7 +294,7 @@ class YotiTest extends DrupalWebTestCase {
     $this->drupalGet('user');
 
     $this->assertElementByXpath(
-      "//div[contains(@class,:wrapper_class)]//a[@href=:href][@id=:id]",
+      "//div[@class=:wrapper_class]//a[@href=:href][@id=:id][@class=:class]",
       array(
         ':wrapper_class' => 'yoti-connect',
         ':href' => '/yoti/unlink',


### PR DESCRIPTION
> Fix for #43 

This should fix the failure on drupal.org https://dispatcher.drupalci.org/job/drupal_d7/6038/console

The tests are run through a headless browser on drupal.org, which means there's no user setup for the tests being run in the cli.