### PR TITLE
SDK-941: Drupal CI

### DIFF
--- a/docker/run-tests.sh
+++ b/docker/run-tests.sh
@@ -2,7 +2,7 @@
 TARGET="drupal-7-dev"
 
 # Coding Standards
-docker-compose exec $TARGET ./vendor/bin/phpcs --standard=Drupal --ignore=*yoti/sdk* ./sites/all/modules/yoti
+docker-compose exec $TARGET sh -c "cd ./sites/all/modules/yoti && /var/www/html/vendor/bin/phpcs"
 
 # Enable Yoti module
 docker-compose exec $TARGET drush en simpletest -y

--- a/yoti/phpcs.xml
+++ b/yoti/phpcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="Yoti">
+  <rule ref="Drupal"/>
+  <file>.</file>
+  <exclude-pattern>/sdk/</exclude-pattern>
+</ruleset>

--- a/yoti/tests/yoti.test
+++ b/yoti/tests/yoti.test
@@ -430,9 +430,6 @@ class YotiTest extends DrupalWebTestCase {
    * Test Register Form.
    */
   public function testRegisterForm() {
-    global $user;
-    $user = drupal_anonymous_user();
-
     module_load_include('inc', 'yoti', 'yoti.pages');
 
     // Set session data.
@@ -502,6 +499,9 @@ class YotiTest extends DrupalWebTestCase {
       strstr($form['#attached']['css'][0]['data'], 'yoti/css/yoti.css'),
       'Check CSS is attached to form'
     );
+
+    // Clean up session.
+    unset($_SESSION['yoti-user']);
   }
 
   /**

--- a/yoti/tests/yoti.test
+++ b/yoti/tests/yoti.test
@@ -294,7 +294,7 @@ class YotiTest extends DrupalWebTestCase {
     $this->drupalGet('user');
 
     $this->assertElementByXpath(
-      "//div[@class=:wrapper_class]//a[@href=:href][@id=:id][@class=:class]",
+      "//div[@class=:wrapper_class]//a[contains(@href,:href)][@id=:id][@class=:class]",
       array(
         ':wrapper_class' => 'yoti-connect',
         ':href' => '/yoti/unlink',


### PR DESCRIPTION
### Fixed
- Updated xpath to check for link containing `/yoti/unlink` as Drupal CI runs with a base path
- Clean up session data so that it isn't committed at the end of the test run _(setting the global user didn't resolve the issue as this is reset before the session is committed)_

### Added
- Code Sniffer config to exclude SDK directory

> Note: merging into 7.x-2.x to push to Drupal CI