### PR TITLE
SDK-887: Drupal CI

### DIFF
--- a/docker/phpunit.xml
+++ b/docker/phpunit.xml
@@ -4,7 +4,6 @@
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true"
-         checkForUnintentionallyCoveredCode="false"
          verbose="true">
     <php>
         <!-- Set error reporting to E_ALL. -->

--- a/docker/phpunit.xml
+++ b/docker/phpunit.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         backupGlobals="false"
+<phpunit bootstrap="core/tests/bootstrap.php"
          colors="true"
-         bootstrap="core/tests/bootstrap.php"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         checkForUnintentionallyCoveredCode="false"
+         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter"
          verbose="true">
     <php>
+        <!-- Set error reporting to E_ALL. -->
+        <ini name="error_reporting" value="32767"/>
         <env name="SIMPLETEST_BASE_URL" value="https://localhost"/>
         <env name="SIMPLETEST_DB" value="mysql://drupal:drupal@drupal-8-db/drupal"/>
     </php>

--- a/docker/phpunit.xml
+++ b/docker/phpunit.xml
@@ -5,7 +5,6 @@
          beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true"
          checkForUnintentionallyCoveredCode="false"
-         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter"
          verbose="true">
     <php>
         <!-- Set error reporting to E_ALL. -->

--- a/docker/run-tests.sh
+++ b/docker/run-tests.sh
@@ -3,7 +3,7 @@ docker-compose up -d drupal-8-dev
 sleep 10
 
 # Coding Standards
-docker-compose exec drupal-8-dev ./vendor/bin/phpcs --standard=Drupal --ignore=*/var/www/html/modules/yoti/sdk* ./modules/yoti
+docker-compose exec drupal-8-dev ./vendor/bin/phpcs ./modules/yoti
 
 # Run Unit Tests
 docker-compose exec drupal-8-dev sudo -u www-data ./vendor/bin/phpunit

--- a/docker/run-tests.sh
+++ b/docker/run-tests.sh
@@ -3,7 +3,7 @@ docker-compose up -d drupal-8-dev
 sleep 10
 
 # Coding Standards
-docker-compose exec drupal-8-dev ./vendor/bin/phpcs ./modules/yoti
+docker-compose exec drupal-8-dev sh -c "cd modules/yoti && ../../vendor/bin/phpcs"
 
 # Run Unit Tests
 docker-compose exec drupal-8-dev sudo -u www-data ./vendor/bin/phpunit

--- a/yoti/phpcs.xml
+++ b/yoti/phpcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="Yoti">
+  <rule ref="Drupal"/>
+  <file>.</file>
+  <exclude-pattern>/sdk/</exclude-pattern>
+</ruleset>

--- a/yoti/tests/src/Functional/YotiBrowserTestBase.php
+++ b/yoti/tests/src/Functional/YotiBrowserTestBase.php
@@ -10,7 +10,7 @@ use Drupal\yoti\YotiHelper;
  *
  * @group yoti
  */
-class YotiBrowserTestBase extends BrowserTestBase {
+abstract class YotiBrowserTestBase extends BrowserTestBase {
 
   /**
    * Linked User.

--- a/yoti/tests/src/Functional/YotiBrowserTestBase.php
+++ b/yoti/tests/src/Functional/YotiBrowserTestBase.php
@@ -80,7 +80,9 @@ abstract class YotiBrowserTestBase extends BrowserTestBase {
       mkdir(YotiHelper::uploadDir(), 0777, TRUE);
     }
     $this->selfieFilePath = YotiHelper::uploadDir() . DIRECTORY_SEPARATOR . 'test_selfie.jpg';
-    file_put_contents($this->selfieFilePath, 'test_selfie_contents');
+    if (!is_file($this->selfieFilePath)) {
+      file_put_contents($this->selfieFilePath, 'test_selfie_contents');
+    }
     $user_data[YotiHelper::ATTR_SELFIE_FILE_NAME] = basename($this->selfieFilePath);
 
     \Drupal::database()->insert(YotiHelper::YOTI_USER_TABLE_NAME)->fields([
@@ -90,21 +92,6 @@ abstract class YotiBrowserTestBase extends BrowserTestBase {
     ])->execute();
 
     return $linkedUser;
-  }
-
-  /**
-   * Teardown Tests.
-   */
-  public function teardown() {
-    // Cleanup selfie.
-    if (is_file($this->selfieFilePath)) {
-      unlink($this->selfieFilePath);
-    }
-
-    // Cleanup private directory.
-    rmdir(YotiHelper::uploadDir());
-
-    parent::teardown();
   }
 
 }

--- a/yoti/tests/src/Functional/YotiProfileTest.php
+++ b/yoti/tests/src/Functional/YotiProfileTest.php
@@ -25,7 +25,7 @@ class YotiProfileTest extends YotiBrowserTestBase {
     // Check unlink button is present.
     $this->assertSession()->elementTextContains(
       'css',
-      "#yoti-unlink-button[href='/yoti/unlink']",
+      "#yoti-unlink-button[href*='/yoti/unlink']",
       'Unlink Yoti account'
     );
   }

--- a/yoti/tests/src/Functional/YotiUnlinkFormTest.php
+++ b/yoti/tests/src/Functional/YotiUnlinkFormTest.php
@@ -19,7 +19,7 @@ class YotiUnlinkFormTest extends YotiBrowserTestBase {
     $assert = $this->assertSession();
     $assert->elementTextContains(
       'css',
-      "#yoti-unlink-button[href='/yoti/unlink']",
+      "#yoti-unlink-button[href*='/yoti/unlink']",
       'Unlink Yoti account'
     );
 

--- a/yoti/tests/src/Unit/YotiConfigTest.php
+++ b/yoti/tests/src/Unit/YotiConfigTest.php
@@ -55,7 +55,9 @@ class YotiConfigTest extends YotiUnitTestBase {
 
     // Create test pem file.
     $this->pemFilePath = $this->tmpDir . DIRECTORY_SEPARATOR . 'yoti_config_test.pem';
-    file_put_contents($this->pemFilePath, 'test_pem_content');
+    if (!is_file($this->pemFilePath)) {
+      file_put_contents($this->pemFilePath, 'test_pem_content');
+    }
 
     // Mock the config factory with Yoti settings.
     $configFactory = $this->getConfigFactoryStub([
@@ -67,18 +69,6 @@ class YotiConfigTest extends YotiUnitTestBase {
       $this->createMockFileSystem(),
       $this->createMockEntityTypeManager()
     );
-  }
-
-  /**
-   * Clean up test data.
-   */
-  public function teardown() {
-    // Remove test file.
-    if (is_file($this->pemFilePath)) {
-      unlink($this->pemFilePath);
-    }
-
-    parent::teardown();
   }
 
   /**

--- a/yoti/tests/src/Unit/YotiHelperTest.php
+++ b/yoti/tests/src/Unit/YotiHelperTest.php
@@ -51,21 +51,11 @@ class YotiHelperTest extends YotiUnitTestBase {
 
     // Create test selfie file.
     $this->selfieFilePath = $this->tmpDir . DIRECTORY_SEPARATOR . 'test_selfie.jpg';
-    file_put_contents($this->selfieFilePath, 'test_selfie_contents');
-
-    $this->createContainer();
-  }
-
-  /**
-   * Clean up test data.
-   */
-  public function teardown() {
-    // Remove test file.
-    if (is_file($this->selfieFilePath)) {
-      unlink($this->selfieFilePath);
+    if (!is_file($this->selfieFilePath)) {
+      file_put_contents($this->selfieFilePath, 'test_selfie_contents');
     }
 
-    parent::teardown();
+    $this->createContainer();
   }
 
   /**

--- a/yoti/tests/src/Unit/YotiUnitTestBase.php
+++ b/yoti/tests/src/Unit/YotiUnitTestBase.php
@@ -10,6 +10,13 @@ use Drupal\Tests\UnitTestCase;
 abstract class YotiUnitTestBase extends UnitTestCase {
 
   /**
+   * Original $_GET value.
+   *
+   * @var array
+   */
+  private $originalGet;
+
+  /**
    * Test file directory.
    *
    * @var string
@@ -20,6 +27,8 @@ abstract class YotiUnitTestBase extends UnitTestCase {
    * Setup Yoti tests.
    */
   public function setup() {
+    $this->originalGet = $_GET;
+
     parent::setup();
 
     // Create tmp file directory.
@@ -33,6 +42,8 @@ abstract class YotiUnitTestBase extends UnitTestCase {
    * Clean up test data.
    */
   public function teardown() {
+    $_GET = $this->originalGet;
+
     // Remove test file directory.
     if (is_dir($this->tmpDir)) {
       rmdir($this->tmpDir);

--- a/yoti/tests/src/Unit/YotiUnitTestBase.php
+++ b/yoti/tests/src/Unit/YotiUnitTestBase.php
@@ -43,12 +43,6 @@ abstract class YotiUnitTestBase extends UnitTestCase {
    */
   public function teardown() {
     $_GET = $this->originalGet;
-
-    // Remove test file directory.
-    if (is_dir($this->tmpDir)) {
-      rmdir($this->tmpDir);
-    }
-
     parent::teardown();
   }
 


### PR DESCRIPTION
### Fixed
- Made `YotiBrowserTestBase` _abstract_ so that it isn't run as a standalone test.
- Restore $_GET on teardown to prevent risky warnings
- Removed cleanup of test files and directory from teardown to allow for concurrency _(the test file doesn't need to be unique)_

### Changed
- PHPUnit config to match Drupal CI (it will catch "risky" tests)

### Added
- Code Sniffer config to exclude `sdk` directory on Drupal CI

> Note: merging into 8.x-2.x to push to drupal.org