### PR TITLE
SDK-941: Support non-clean URLs

### DIFF
--- a/yoti/tests/yoti.test
+++ b/yoti/tests/yoti.test
@@ -297,7 +297,7 @@ class YotiTest extends DrupalWebTestCase {
       "//div[@class=:wrapper_class]//a[contains(@href,:href)][@id=:id][@class=:class]",
       array(
         ':wrapper_class' => 'yoti-connect',
-        ':href' => '/yoti/unlink',
+        ':href' => 'yoti/unlink',
         ':id' => 'yoti-unlink-button',
         ':class' => 'button',
       ),


### PR DESCRIPTION
### Removed
- Leading slash for non clean URLs (Drupal CI runs without clean URLs, which means links will be in the format `index.php?q=yoti/unlink`)

I have run this locally using following https://www.drupal.org/drupalorg/docs/drupal-ci/running-drupalci-locally and can confirm it resolves the failure