### PR TITLE
SDK-1157: Trim text fields when saved

### DIFF
--- a/yoti/src/Form/YotiSettingsForm.php
+++ b/yoti/src/Form/YotiSettingsForm.php
@@ -176,16 +176,16 @@ class YotiSettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $values = $form_state->getValues();
     $this->config('yoti.settings')
-      ->set('yoti_app_id', $values['yoti_app_id'])
-      ->set('yoti_scenario_id', $values['yoti_scenario_id'])
-      ->set('yoti_sdk_id', $values['yoti_sdk_id'])
-      ->set('yoti_success_url', $values['yoti_success_url'])
-      ->set('yoti_fail_url', $values['yoti_fail_url'])
+      ->set('yoti_app_id', trim($values['yoti_app_id']))
+      ->set('yoti_scenario_id', trim($values['yoti_scenario_id']))
+      ->set('yoti_sdk_id', trim($values['yoti_sdk_id']))
+      ->set('yoti_success_url', trim($values['yoti_success_url']))
+      ->set('yoti_fail_url', trim($values['yoti_fail_url']))
       ->set('yoti_pem', $values['yoti_pem'])
       ->set('yoti_age_verification', $values['yoti_age_verification'])
       ->set('yoti_only_existing', $values['yoti_only_existing'])
       ->set('yoti_user_email', $values['yoti_user_email'])
-      ->set('yoti_company_name', $values['yoti_company_name'])
+      ->set('yoti_company_name', trim($values['yoti_company_name']))
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/yoti/tests/src/Functional/YotiSettingsFormTest.php
+++ b/yoti/tests/src/Functional/YotiSettingsFormTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\Tests\yoti\Functional;
+
+use Drupal\user\RoleInterface;
+use Drupal\user\Entity\Role;
+use Drupal\file\Entity\File;
+
+/**
+ * Tests the Yoti Settings Form.
+ *
+ * @group yoti
+ */
+class YotiSettingsFormTest extends YotiBrowserTestBase {
+
+  /**
+   * User's role ID.
+   *
+   * @var string
+   */
+  protected $rid;
+
+  /**
+   * Setup settings form tests.
+   */
+  public function setUp() {
+    parent::setUp();
+
+    // Get the new role ID.
+    $all_rids = $this->unlinkedUser
+      ->getRoles();
+    unset($all_rids[array_search(RoleInterface::AUTHENTICATED_ID, $all_rids)]);
+    $this->rid = reset($all_rids);
+
+    // Log test user in before each test.
+    $this->drupalLogin($this->unlinkedUser);
+
+    // Allow user to configure module.
+    $role = Role::load($this->rid);
+    $role->grantPermission('administer yoti');
+    $role->save();
+
+    // Create a test pem file so that admin form can be saved.
+    $file = File::create([
+      'uri' => 'private://test.pem',
+    ]);
+    $file->save();
+    $this->config('yoti.settings')
+      ->set('yoti_pem', [$file->id()])
+      ->save();
+  }
+
+  /**
+   * Test settings form submission.
+   */
+  public function testSettingsFormSubmission() {
+    $this->drupalGet('admin/config/people/yoti');
+
+    $assert = $this->assertSession();
+    $assert->statusCodeEquals(200);
+
+    $page = $this->getSession()->getPage();
+
+    $form_values = [
+      'App ID' => 'test_app_id',
+      'Scenario ID' => 'test_scenario_id',
+      'Client SDK ID' => 'test_client_sdk_id',
+      'Company Name' => 'test_company_name',
+      'Success URL' => '/user',
+      'Fail URL' => '/fail',
+    ];
+    foreach ($form_values as $label => $value) {
+      $page->fillField($label, $value . "\t \n\r\x0B");
+    }
+    $page->pressButton('Save configuration');
+
+    foreach($form_values as $value) {
+      $assert->elementExists('css', sprintf("input[value='%s']", htmlspecialchars($value)));
+    }
+
+  }
+
+}


### PR DESCRIPTION
### Fixed
- Text fields are now trimmed to remove any leading/trailing whitespace