### PR TITLE
Release 8.x-1.5

### DIFF
--- a/checkout-sdk.sh
+++ b/checkout-sdk.sh
@@ -5,7 +5,7 @@
 
 NAME="yoti-for-drupal-8.x-1.x-edge.zip"
 SDK_TAG=$1
-DEFAULT_SDK_TAG="1.2.1"
+DEFAULT_SDK_TAG="1.2.2"
 
 if [ "$SDK_TAG" = "" ]; then
     SDK_TAG=$DEFAULT_SDK_TAG


### PR DESCRIPTION
#### Security
- Default Curl request handler now verifies host and peer certificates. Only the unencrypted parts of the receipt were at risk, as user profiles are always encrypted